### PR TITLE
Fix InputStream leak in image retrieval

### DIFF
--- a/src/main/java/com/keroleap/immerreader/Controller/AristonController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/AristonController.java
@@ -154,7 +154,7 @@ private BufferedImage getBufferedImage(String imageUrl) throws IOException {
             outputStream.write(chunk, 0, bytesRead);
         }
 
-        url.openStream().close();
+        stream.close();
         byte[] data = outputStream.toByteArray();
         ByteArrayInputStream input = new ByteArrayInputStream(data);
         BufferedImage image = ImageIO.read(input);

--- a/src/main/java/com/keroleap/immerreader/Controller/ImmerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/ImmerController.java
@@ -200,7 +200,7 @@ private BufferedImage getBufferedImage(String imageUrl) throws IOException {
             outputStream.write(chunk, 0, bytesRead);
         }
 
-        url.openStream().close();
+        stream.close();
         byte[] data = outputStream.toByteArray();
         ByteArrayInputStream input = new ByteArrayInputStream(data);
         BufferedImage image = ImageIO.read(input);

--- a/src/main/java/com/keroleap/immerreader/Scheduler/AristonScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/AristonScheduler.java
@@ -78,7 +78,7 @@ public class AristonScheduler {
             outputStream.write(chunk, 0, bytesRead);
         }
 
-        url.openStream().close();
+        stream.close();
         byte[] data = outputStream.toByteArray();
         ByteArrayInputStream input = new ByteArrayInputStream(data);
         BufferedImage image = ImageIO.read(input);

--- a/src/main/java/com/keroleap/immerreader/Scheduler/ImmerScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/ImmerScheduler.java
@@ -177,7 +177,7 @@ private BufferedImage getBufferedImage(String imageUrl) throws IOException {
             outputStream.write(chunk, 0, bytesRead);
         }
 
-        url.openStream().close();
+        stream.close();
         byte[] data = outputStream.toByteArray();
         ByteArrayInputStream input = new ByteArrayInputStream(data);
         BufferedImage image = ImageIO.read(input);


### PR DESCRIPTION
## Summary
- close the original URL input stream instead of opening a new one

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbd2c19b08329aebe76ed70c8a050