### PR TITLE
Fix resource leaks in image capture

### DIFF
--- a/src/main/java/com/keroleap/immerreader/Controller/AristonController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/AristonController.java
@@ -3,7 +3,6 @@ package com.keroleap.immerreader.Controller;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -136,31 +135,20 @@ private AristonRest getAristonRestData(BufferedImage bufferedImage) {
 
 
 private BufferedImage getBufferedImage(String imageUrl) throws IOException {
-
-    URL url = null;
     try {
-        url = new URL(imageUrl);
-    } catch (MalformedURLException e) {
-        e.printStackTrace();
-    }
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        URL url = new URL(imageUrl);
+        try (InputStream stream = url.openStream();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            byte[] chunk = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = stream.read(chunk)) > 0) {
+                outputStream.write(chunk, 0, bytesRead);
+            }
 
-    try {
-        byte[] chunk = new byte[4096];
-        int bytesRead;
-        InputStream stream = url.openStream();
-
-        while ((bytesRead = stream.read(chunk)) > 0) {
-            outputStream.write(chunk, 0, bytesRead);
+            try (ByteArrayInputStream input = new ByteArrayInputStream(outputStream.toByteArray())) {
+                return ImageIO.read(input);
+            }
         }
-
-        stream.close();
-        byte[] data = outputStream.toByteArray();
-        ByteArrayInputStream input = new ByteArrayInputStream(data);
-        BufferedImage image = ImageIO.read(input);
-        outputStream.close();
-        return image;
-
     } catch (IOException e) {
         e.printStackTrace();
         return null;

--- a/src/main/java/com/keroleap/immerreader/Controller/ImmerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/ImmerController.java
@@ -3,7 +3,6 @@ package com.keroleap.immerreader.Controller;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -182,31 +181,20 @@ public int getNumber(boolean digit1_1, boolean digit1_2, boolean digit1_3, boole
 }
 
 private BufferedImage getBufferedImage(String imageUrl) throws IOException {
-
-    URL url = null;
     try {
-        url = new URL(imageUrl);
-    } catch (MalformedURLException e) {
-        e.printStackTrace();
-    }
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        URL url = new URL(imageUrl);
+        try (InputStream stream = url.openStream();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            byte[] chunk = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = stream.read(chunk)) > 0) {
+                outputStream.write(chunk, 0, bytesRead);
+            }
 
-    try {
-        byte[] chunk = new byte[4096];
-        int bytesRead;
-        InputStream stream = url.openStream();
-
-        while ((bytesRead = stream.read(chunk)) > 0) {
-            outputStream.write(chunk, 0, bytesRead);
+            try (ByteArrayInputStream input = new ByteArrayInputStream(outputStream.toByteArray())) {
+                return ImageIO.read(input);
+            }
         }
-
-        stream.close();
-        byte[] data = outputStream.toByteArray();
-        ByteArrayInputStream input = new ByteArrayInputStream(data);
-        BufferedImage image = ImageIO.read(input);
-        outputStream.close();
-        return image;
-
     } catch (IOException e) {
         e.printStackTrace();
         return null;

--- a/src/main/java/com/keroleap/immerreader/Scheduler/AristonScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/AristonScheduler.java
@@ -3,7 +3,6 @@ package com.keroleap.immerreader.Scheduler;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,36 +59,25 @@ public class AristonScheduler {
 
 
     private BufferedImage getBufferedImage(String imageUrl) throws IOException {
+        try {
+            URL url = new URL(imageUrl);
+            try (InputStream stream = url.openStream();
+                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                byte[] chunk = new byte[4096];
+                int bytesRead;
+                while ((bytesRead = stream.read(chunk)) > 0) {
+                    outputStream.write(chunk, 0, bytesRead);
+                }
 
-    URL url = null;
-    try {
-        url = new URL(imageUrl);
-    } catch (MalformedURLException e) {
-        e.printStackTrace();
-    }
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-    try {
-        byte[] chunk = new byte[4096];
-        int bytesRead;
-        InputStream stream = url.openStream();
-
-        while ((bytesRead = stream.read(chunk)) > 0) {
-            outputStream.write(chunk, 0, bytesRead);
+                try (ByteArrayInputStream input = new ByteArrayInputStream(outputStream.toByteArray())) {
+                    return ImageIO.read(input);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
         }
-
-        stream.close();
-        byte[] data = outputStream.toByteArray();
-        ByteArrayInputStream input = new ByteArrayInputStream(data);
-        BufferedImage image = ImageIO.read(input);
-        outputStream.close();
-        return image;
-
-    } catch (IOException e) {
-        e.printStackTrace();
-        return null;
     }
-}
 
 private AristonRest getAristonRestData(BufferedImage bufferedImage) {
     boolean percent_0 = getLightValueAnnDrawRedCross( 160, 160 ,  bufferedImage);

--- a/src/main/java/com/keroleap/immerreader/Scheduler/ImmerScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/ImmerScheduler.java
@@ -4,7 +4,6 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -159,31 +158,20 @@ public int getNumber(boolean digit1_1, boolean digit1_2, boolean digit1_3, boole
 }
 
 private BufferedImage getBufferedImage(String imageUrl) throws IOException {
-
-    URL url = null;
     try {
-        url = new URL(imageUrl);
-    } catch (MalformedURLException e) {
-        e.printStackTrace();
-    }
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        URL url = new URL(imageUrl);
+        try (InputStream stream = url.openStream();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            byte[] chunk = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = stream.read(chunk)) > 0) {
+                outputStream.write(chunk, 0, bytesRead);
+            }
 
-    try {
-        byte[] chunk = new byte[4096];
-        int bytesRead;
-        InputStream stream = url.openStream();
-
-        while ((bytesRead = stream.read(chunk)) > 0) {
-            outputStream.write(chunk, 0, bytesRead);
+            try (ByteArrayInputStream input = new ByteArrayInputStream(outputStream.toByteArray())) {
+                return ImageIO.read(input);
+            }
         }
-
-        stream.close();
-        byte[] data = outputStream.toByteArray();
-        ByteArrayInputStream input = new ByteArrayInputStream(data);
-        BufferedImage image = ImageIO.read(input);
-        outputStream.close();
-        return image;
-
     } catch (IOException e) {
         e.printStackTrace();
         return null;


### PR DESCRIPTION
## Summary
- close HTTP streams with try-with-resources
- remove unused `MalformedURLException` imports

## Testing
- `./mvnw -q test` *(fails: cannot open maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_687689476be483299be6d9a4d9670406