### PR TITLE
Web UI: Add ImmerManager and AristonManager with navigation

### DIFF
--- a/src/main/java/com/keroleap/immerreader/Controller/AristonManagerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/AristonManagerController.java
@@ -1,0 +1,42 @@
+package com.keroleap.immerreader.Controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.keroleap.immerreader.SharedData.AristonManagerData;
+
+@Controller
+@RequestMapping("/AristonManager")
+public class AristonManagerController {
+
+    @Autowired
+    private AristonManagerData aristonManagerData;
+
+    @PostMapping("/set")
+    @ResponseBody
+    public AristonManagerData setOffset(@RequestParam int x, @RequestParam int y) {
+        aristonManagerData.setOffsetX(x);
+        aristonManagerData.setOffsetY(y);
+        return aristonManagerData;
+    }
+
+    @GetMapping
+    @ResponseBody
+    public AristonManagerData getOffset() {
+        return aristonManagerData;
+    }
+
+    @GetMapping("/adjust")
+    public ModelAndView adjustOffset() {
+        ModelAndView modelAndView = new ModelAndView("ariston-manager");
+        modelAndView.addObject("offsetX", aristonManagerData.getOffsetX());
+        modelAndView.addObject("offsetY", aristonManagerData.getOffsetY());
+        return modelAndView;
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/Controller/ImmerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/ImmerController.java
@@ -18,7 +18,7 @@ import org.springframework.web.servlet.ModelAndView;
 import com.keroleap.immerreader.ImmerRest;
 import com.keroleap.immerreader.Service.ImmerAnalyzerService;
 import com.keroleap.immerreader.SharedData.ImmerData;
-import com.keroleap.immerreader.SharedData.ImmerOffsetData;
+import com.keroleap.immerreader.SharedData.ImmerManagerData;
 
 @Controller
 @RequestMapping("/Immer")
@@ -32,12 +32,12 @@ private ImmerData immerData;
 private ImmerAnalyzerService immerAnalyzerService;
 
 @Autowired
-private ImmerOffsetData immerOffsetData;
+private ImmerManagerData immerManagerData;
 
 @GetMapping(value = "/image", produces = MediaType.IMAGE_JPEG_VALUE)
 public @ResponseBody byte[] getImage() throws IOException {
     BufferedImage cachedImage = immerAnalyzerService.getBufferedImage("http://192.168.1.196/image/jpeg.cgi");
-    immerAnalyzerService.getImmerRestData(cachedImage, immerOffsetData.getOffsetX(), immerOffsetData.getOffsetY());
+    immerAnalyzerService.getImmerRestData(cachedImage, immerManagerData.getOffsetX(), immerManagerData.getOffsetY());
     int x1 = 90; // the x-coordinate of the top-left corner of the crop area
     int y1 = 35; // the y-coordinate of the top-left corner of the crop area
     int x2 = 240; // the x-coordinate of the bottom-right corner of the crop area
@@ -58,7 +58,7 @@ public @ResponseBody byte[] getImage() throws IOException {
 @GetMapping(value = "/uncroppedimage", produces = MediaType.IMAGE_JPEG_VALUE)
 public @ResponseBody byte[] getUncroppedImage() throws IOException {
     BufferedImage cachedImage = immerAnalyzerService.getBufferedImage("http://192.168.1.196/image/jpeg.cgi");
-    immerAnalyzerService.getImmerRestData(cachedImage, immerOffsetData.getOffsetX(), immerOffsetData.getOffsetY());
+    immerAnalyzerService.getImmerRestData(cachedImage, immerManagerData.getOffsetX(), immerManagerData.getOffsetY());
 
     // Crop the image
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -72,7 +72,7 @@ public @ResponseBody byte[] getUncroppedImage() throws IOException {
 public ModelAndView getImmerData() throws IOException {
     BufferedImage cachedImage = immerAnalyzerService.getBufferedImage("http://192.168.1.196/image/jpeg.cgi");
     ModelAndView modelAndView = new ModelAndView("immerdata");
-    modelAndView.addObject("message", immerAnalyzerService.getImmerRestData(cachedImage, immerOffsetData.getOffsetX(), immerOffsetData.getOffsetY()).toString());
+    modelAndView.addObject("message", immerAnalyzerService.getImmerRestData(cachedImage, immerManagerData.getOffsetX(), immerManagerData.getOffsetY()).toString());
     return modelAndView;
 }
 

--- a/src/main/java/com/keroleap/immerreader/Controller/ImmerManagerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/ImmerManagerController.java
@@ -9,34 +9,34 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
-import com.keroleap.immerreader.SharedData.ImmerOffsetData;
+import com.keroleap.immerreader.SharedData.ImmerManagerData;
 
 @Controller
-@RequestMapping("/ImmerOffset")
-public class ImmerOffsetController {
+@RequestMapping("/ImmerManager")
+public class ImmerManagerController {
 
     @Autowired
-    private ImmerOffsetData immerOffsetData;
+    private ImmerManagerData immerManagerData;
 
     @PostMapping("/set")
     @ResponseBody
-    public ImmerOffsetData setOffset(@RequestParam int x, @RequestParam int y) {
-        immerOffsetData.setOffsetX(x);
-        immerOffsetData.setOffsetY(y);
-        return immerOffsetData;
+    public ImmerManagerData setOffset(@RequestParam int x, @RequestParam int y) {
+        immerManagerData.setOffsetX(x);
+        immerManagerData.setOffsetY(y);
+        return immerManagerData;
     }
 
     @GetMapping
     @ResponseBody
-    public ImmerOffsetData getOffset() {
-        return immerOffsetData;
+    public ImmerManagerData getOffset() {
+        return immerManagerData;
     }
 
     @GetMapping("/adjust")
     public ModelAndView adjustOffset() {
-        ModelAndView modelAndView = new ModelAndView("offset-adjuster");
-        modelAndView.addObject("offsetX", immerOffsetData.getOffsetX());
-        modelAndView.addObject("offsetY", immerOffsetData.getOffsetY());
+        ModelAndView modelAndView = new ModelAndView("immer-manager");
+        modelAndView.addObject("offsetX", immerManagerData.getOffsetX());
+        modelAndView.addObject("offsetY", immerManagerData.getOffsetY());
         return modelAndView;
     }
 }

--- a/src/main/java/com/keroleap/immerreader/Scheduler/ImmerScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/ImmerScheduler.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import com.keroleap.immerreader.ImmerRest;
 import com.keroleap.immerreader.Service.ImmerAnalyzerService;
 import com.keroleap.immerreader.SharedData.ImmerData;
-import com.keroleap.immerreader.SharedData.ImmerOffsetData;
+import com.keroleap.immerreader.SharedData.ImmerManagerData;
 
 import jakarta.annotation.PreDestroy;
 
@@ -32,14 +32,14 @@ public class ImmerScheduler {
     private ImmerAnalyzerService immerAnalyzerService;
 
     @Autowired
-    private ImmerOffsetData immerOffsetData;
+    private ImmerManagerData immerManagerData;
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     @Scheduled(fixedRate = 2000)
     public void ImmerScheduledRead() {
-        int offsetX = immerOffsetData.getOffsetX();
-        int offsetY = immerOffsetData.getOffsetY();
+        int offsetX = immerManagerData.getOffsetX();
+        int offsetY = immerManagerData.getOffsetY();
         Future<ImmerRest> future = executor.submit(() -> {
             BufferedImage cachedImage = immerAnalyzerService.getBufferedImage("http://192.168.1.196/image/jpeg.cgi");
             return immerAnalyzerService.getImmerRestData(cachedImage, offsetX, offsetY);

--- a/src/main/java/com/keroleap/immerreader/SharedData/AristonManagerData.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/AristonManagerData.java
@@ -14,9 +14,9 @@ import org.springframework.stereotype.Component;
 import jakarta.annotation.PostConstruct;
 
 @Component
-public class ImmerOffsetData {
-    private static final Logger logger = LoggerFactory.getLogger(ImmerOffsetData.class);
-    private static final String DATA_FILE = "/data/offset.properties";
+public class AristonManagerData {
+    private static final Logger logger = LoggerFactory.getLogger(AristonManagerData.class);
+    private static final String DATA_FILE = "/data/ariston.properties";
 
     private final AtomicInteger offsetX = new AtomicInteger(0);
     private final AtomicInteger offsetY = new AtomicInteger(0);

--- a/src/main/java/com/keroleap/immerreader/SharedData/ImmerManagerData.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/ImmerManagerData.java
@@ -1,0 +1,73 @@
+package com.keroleap.immerreader.SharedData;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class ImmerManagerData {
+    private static final Logger logger = LoggerFactory.getLogger(ImmerManagerData.class);
+    private static final String DATA_FILE = "/data/offset.properties";
+
+    private final AtomicInteger offsetX = new AtomicInteger(0);
+    private final AtomicInteger offsetY = new AtomicInteger(0);
+
+    @PostConstruct
+    private void load() {
+        File file = new File(DATA_FILE);
+        if (file.exists()) {
+            Properties props = new Properties();
+            try (FileInputStream fis = new FileInputStream(file)) {
+                props.load(fis);
+                offsetX.set(Integer.parseInt(props.getProperty("offsetX", "0")));
+                offsetY.set(Integer.parseInt(props.getProperty("offsetY", "0")));
+            } catch (IOException | NumberFormatException e) {
+                logger.warn("Could not load offset data from {}: {}", DATA_FILE, e.getMessage());
+            }
+        }
+    }
+
+    private void save() {
+        Properties props = new Properties();
+        props.setProperty("offsetX", String.valueOf(offsetX.get()));
+        props.setProperty("offsetY", String.valueOf(offsetY.get()));
+        File file = new File(DATA_FILE);
+        File parent = file.getParentFile();
+        if (!parent.exists() && !parent.mkdirs()) {
+            logger.warn("Could not create directory {}", parent.getAbsolutePath());
+            return;
+        }
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            props.store(fos, null);
+        } catch (IOException e) {
+            logger.warn("Could not save offset data to {}: {}", DATA_FILE, e.getMessage());
+        }
+    }
+
+    public int getOffsetX() {
+        return offsetX.get();
+    }
+
+    public void setOffsetX(int offsetX) {
+        this.offsetX.set(offsetX);
+        save();
+    }
+
+    public int getOffsetY() {
+        return offsetY.get();
+    }
+
+    public void setOffsetY(int offsetY) {
+        this.offsetY.set(offsetY);
+        save();
+    }
+}

--- a/src/main/resources/templates/ariston-manager.html
+++ b/src/main/resources/templates/ariston-manager.html
@@ -1,0 +1,188 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Ariston Manager</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #1a1a2e;
+            color: #eee;
+        }
+        nav {
+            background: #0f3460;
+            padding: 15px 20px;
+            margin-bottom: 20px;
+        }
+        nav a {
+            color: #eee;
+            text-decoration: none;
+            margin-right: 20px;
+            padding: 8px 16px;
+            border-radius: 4px;
+            transition: background 0.3s;
+        }
+        nav a:hover {
+            background: #e94560;
+        }
+        nav a.active {
+            background: #e94560;
+        }
+        .container {
+            display: flex;
+            gap: 20px;
+            align-items: flex-start;
+            padding: 0 20px;
+        }
+        .controls {
+            background: #16213e;
+            padding: 20px;
+            border-radius: 8px;
+            min-width: 250px;
+        }
+        .form-group {
+            margin-bottom: 15px;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        input[type="number"] {
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #0f3460;
+            border-radius: 4px;
+            background: #1a1a2e;
+            color: #eee;
+            font-size: 16px;
+        }
+        button {
+            background: #e94560;
+            color: white;
+            padding: 10px 20px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+            width: 100%;
+        }
+        button:hover {
+            background: #ff6b6b;
+        }
+        .image-container {
+            background: #16213e;
+            padding: 20px;
+            border-radius: 8px;
+        }
+        img {
+            max-width: 800px;
+            border: 2px solid #0f3460;
+            border-radius: 4px;
+        }
+        .current-values {
+            margin-top: 15px;
+            padding: 10px;
+            background: #0f3460;
+            border-radius: 4px;
+        }
+        .status {
+            margin-top: 10px;
+            padding: 10px;
+            border-radius: 4px;
+            display: none;
+        }
+        .status.success {
+            background: #28a745;
+            display: block;
+        }
+        h1 {
+            padding: 0 20px;
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <a href="/">Home</a>
+        <a href="/ImmerManager/adjust">Immer Manager</a>
+        <a href="/AristonManager/adjust" class="active">Ariston Manager</a>
+    </nav>
+
+    <h1>Ariston Manager</h1>
+
+    <div class="container">
+        <div class="controls">
+            <form id="offsetForm">
+                <div class="form-group">
+                    <label for="offsetX">Offset X:</label>
+                    <input type="number" id="offsetX" name="x" th:value="${offsetX}" required>
+                </div>
+                <div class="form-group">
+                    <label for="offsetY">Offset Y:</label>
+                    <input type="number" id="offsetY" name="y" th:value="${offsetY}" required>
+                </div>
+                <button type="submit">Apply Offset</button>
+            </form>
+
+            <div class="current-values">
+                <strong>Current Values:</strong><br>
+                X: <span id="currentX" th:text="${offsetX}">0</span><br>
+                Y: <span id="currentY" th:text="${offsetY}">0</span>
+            </div>
+
+            <div id="status" class="status">Offset updated!</div>
+        </div>
+
+        <div class="image-container">
+            <h2>Live Preview</h2>
+            <img id="liveImage" src="/Ariston/uncroppedimage" alt="Ariston Camera Feed">
+            <p><small>Image refreshes automatically every 15 seconds</small></p>
+        </div>
+    </div>
+
+    <script>
+        document.getElementById('offsetForm').addEventListener('submit', function(e) {
+            e.preventDefault();
+
+            const x = document.getElementById('offsetX').value;
+            const y = document.getElementById('offsetY').value;
+
+            fetch('/AristonManager/set', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: `x=${x}&y=${y}`
+            })
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('currentX').textContent = data.offsetX;
+                document.getElementById('currentY').textContent = data.offsetY;
+
+                const status = document.getElementById('status');
+                status.textContent = 'Offset updated!';
+                status.className = 'status success';
+                setTimeout(() => {
+                    status.className = 'status';
+                }, 2000);
+
+                refreshImage();
+            })
+            .catch(error => {
+                console.error('Error:', error);
+            });
+        });
+
+        function refreshImage() {
+            const img = document.getElementById('liveImage');
+            img.src = '/Ariston/uncroppedimage?t=' + new Date().getTime();
+        }
+
+        setInterval(refreshImage, 15000);
+    </script>
+</body>
+</html>

--- a/src/main/resources/templates/immer-manager.html
+++ b/src/main/resources/templates/immer-manager.html
@@ -1,18 +1,42 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>Immer Offset Adjuster</title>
+    <title>Immer Manager</title>
     <style>
+        * {
+            box-sizing: border-box;
+        }
         body {
             font-family: Arial, sans-serif;
-            margin: 20px;
+            margin: 0;
+            padding: 0;
             background-color: #1a1a2e;
             color: #eee;
+        }
+        nav {
+            background: #0f3460;
+            padding: 15px 20px;
+            margin-bottom: 20px;
+        }
+        nav a {
+            color: #eee;
+            text-decoration: none;
+            margin-right: 20px;
+            padding: 8px 16px;
+            border-radius: 4px;
+            transition: background 0.3s;
+        }
+        nav a:hover {
+            background: #e94560;
+        }
+        nav a.active {
+            background: #e94560;
         }
         .container {
             display: flex;
             gap: 20px;
             align-items: flex-start;
+            padding: 0 20px;
         }
         .controls {
             background: #16213e;
@@ -76,10 +100,19 @@
             background: #28a745;
             display: block;
         }
+        h1 {
+            padding: 0 20px;
+        }
     </style>
 </head>
 <body>
-    <h1>Immer Offset Adjuster</h1>
+    <nav>
+        <a href="/">Home</a>
+        <a href="/ImmerManager/adjust" class="active">Immer Manager</a>
+        <a href="/AristonManager/adjust">Ariston Manager</a>
+    </nav>
+
+    <h1>Immer Manager</h1>
 
     <div class="container">
         <div class="controls">
@@ -118,7 +151,7 @@
             const x = document.getElementById('offsetX').value;
             const y = document.getElementById('offsetY').value;
 
-            fetch('/ImmerOffset/set', {
+            fetch('/ImmerManager/set', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>ImmerReader - Home</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #1a1a2e;
+            color: #eee;
+        }
+        nav {
+            background: #0f3460;
+            padding: 15px 20px;
+            margin-bottom: 20px;
+        }
+        nav a {
+            color: #eee;
+            text-decoration: none;
+            margin-right: 20px;
+            padding: 8px 16px;
+            border-radius: 4px;
+            transition: background 0.3s;
+        }
+        nav a:hover {
+            background: #e94560;
+        }
+        nav a.active {
+            background: #e94560;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        h1 {
+            text-align: center;
+            margin-bottom: 40px;
+        }
+        .card-container {
+            display: flex;
+            gap: 20px;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+        .card {
+            background: #16213e;
+            border-radius: 8px;
+            padding: 30px;
+            width: 300px;
+            text-align: center;
+            transition: transform 0.3s, box-shadow 0.3s;
+        }
+        .card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+        }
+        .card h2 {
+            color: #e94560;
+            margin-bottom: 15px;
+        }
+        .card p {
+            color: #aaa;
+            margin-bottom: 20px;
+        }
+        .card a {
+            display: inline-block;
+            background: #e94560;
+            color: white;
+            text-decoration: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            transition: background 0.3s;
+        }
+        .card a:hover {
+            background: #ff6b6b;
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <a href="/" class="active">Home</a>
+        <a href="/ImmerManager/adjust">Immer Manager</a>
+        <a href="/AristonManager/adjust">Ariston Manager</a>
+    </nav>
+
+    <div class="container">
+        <h1>ImmerReader</h1>
+
+        <div class="card-container">
+            <div class="card">
+                <h2>Immer Manager</h2>
+                <p>Configure and monitor your Immergas heating system with live camera feed and offset adjustment.</p>
+                <a href="/ImmerManager/adjust">Open Immer Manager</a>
+            </div>
+
+            <div class="card">
+                <h2>Ariston Manager</h2>
+                <p>Configure and monitor your Ariston heating system with live camera feed and offset adjustment.</p>
+                <a href="/AristonManager/adjust">Open Ariston Manager</a>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/keroleap/immerreader/Controller/AristonManagerControllerTest.java
+++ b/src/test/java/com/keroleap/immerreader/Controller/AristonManagerControllerTest.java
@@ -8,27 +8,27 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import com.keroleap.immerreader.SharedData.ImmerOffsetData;
+import com.keroleap.immerreader.SharedData.AristonManagerData;
 
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(ImmerOffsetController.class)
-class ImmerOffsetControllerTest {
+@WebMvcTest(AristonManagerController.class)
+class AristonManagerControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
     @MockitoBean
-    private ImmerOffsetData immerOffsetData;
+    private AristonManagerData aristonManagerData;
 
     @Test
     void getOffset_returnsCurrentValues() throws Exception {
-        when(immerOffsetData.getOffsetX()).thenReturn(5);
-        when(immerOffsetData.getOffsetY()).thenReturn(10);
+        when(aristonManagerData.getOffsetX()).thenReturn(5);
+        when(aristonManagerData.getOffsetY()).thenReturn(10);
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/ImmerOffset"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/AristonManager"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.offsetX").value(5))
@@ -37,10 +37,10 @@ class ImmerOffsetControllerTest {
 
     @Test
     void getOffset_defaultZeroValues() throws Exception {
-        when(immerOffsetData.getOffsetX()).thenReturn(0);
-        when(immerOffsetData.getOffsetY()).thenReturn(0);
+        when(aristonManagerData.getOffsetX()).thenReturn(0);
+        when(aristonManagerData.getOffsetY()).thenReturn(0);
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/ImmerOffset"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/AristonManager"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.offsetX").value(0))
                 .andExpect(jsonPath("$.offsetY").value(0));
@@ -48,10 +48,10 @@ class ImmerOffsetControllerTest {
 
     @Test
     void setOffset_updatesAndReturnsValues() throws Exception {
-        when(immerOffsetData.getOffsetX()).thenReturn(7);
-        when(immerOffsetData.getOffsetY()).thenReturn(3);
+        when(aristonManagerData.getOffsetX()).thenReturn(7);
+        when(aristonManagerData.getOffsetY()).thenReturn(3);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/ImmerOffset/set")
+        mockMvc.perform(MockMvcRequestBuilders.post("/AristonManager/set")
                         .param("x", "7")
                         .param("y", "3"))
                 .andExpect(status().isOk())
@@ -59,29 +59,29 @@ class ImmerOffsetControllerTest {
                 .andExpect(jsonPath("$.offsetX").value(7))
                 .andExpect(jsonPath("$.offsetY").value(3));
 
-        verify(immerOffsetData).setOffsetX(7);
-        verify(immerOffsetData).setOffsetY(3);
+        verify(aristonManagerData).setOffsetX(7);
+        verify(aristonManagerData).setOffsetY(3);
     }
 
     @Test
     void setOffset_negativeValues() throws Exception {
-        when(immerOffsetData.getOffsetX()).thenReturn(-5);
-        when(immerOffsetData.getOffsetY()).thenReturn(-10);
+        when(aristonManagerData.getOffsetX()).thenReturn(-5);
+        when(aristonManagerData.getOffsetY()).thenReturn(-10);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/ImmerOffset/set")
+        mockMvc.perform(MockMvcRequestBuilders.post("/AristonManager/set")
                         .param("x", "-5")
                         .param("y", "-10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.offsetX").value(-5))
                 .andExpect(jsonPath("$.offsetY").value(-10));
 
-        verify(immerOffsetData).setOffsetX(-5);
-        verify(immerOffsetData).setOffsetY(-10);
+        verify(aristonManagerData).setOffsetX(-5);
+        verify(aristonManagerData).setOffsetY(-10);
     }
 
     @Test
     void setOffset_missingParamReturnsBadRequest() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/ImmerOffset/set")
+        mockMvc.perform(MockMvcRequestBuilders.post("/AristonManager/set")
                         .param("x", "5"))
                 .andExpect(status().isBadRequest());
     }

--- a/src/test/java/com/keroleap/immerreader/Controller/HelloWorldControllerTest.java
+++ b/src/test/java/com/keroleap/immerreader/Controller/HelloWorldControllerTest.java
@@ -11,7 +11,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import com.keroleap.immerreader.ImmerRest;
 import com.keroleap.immerreader.Service.ImmerAnalyzerService;
 import com.keroleap.immerreader.SharedData.ImmerData;
-import com.keroleap.immerreader.SharedData.ImmerOffsetData;
+import com.keroleap.immerreader.SharedData.ImmerManagerData;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -29,7 +29,7 @@ public class HelloWorldControllerTest {
     private ImmerAnalyzerService immerAnalyzerService;
 
     @MockitoBean
-    private ImmerOffsetData immerOffsetData;
+    private ImmerManagerData immerManagerData;
 
     @Test
     public void testGetImmerRestData_returnsJson() throws Exception {

--- a/src/test/java/com/keroleap/immerreader/Controller/ImmerManagerControllerTest.java
+++ b/src/test/java/com/keroleap/immerreader/Controller/ImmerManagerControllerTest.java
@@ -1,0 +1,88 @@
+package com.keroleap.immerreader.Controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.keroleap.immerreader.SharedData.ImmerManagerData;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ImmerManagerController.class)
+class ImmerManagerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ImmerManagerData immerManagerData;
+
+    @Test
+    void getOffset_returnsCurrentValues() throws Exception {
+        when(immerManagerData.getOffsetX()).thenReturn(5);
+        when(immerManagerData.getOffsetY()).thenReturn(10);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/ImmerManager"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.offsetX").value(5))
+                .andExpect(jsonPath("$.offsetY").value(10));
+    }
+
+    @Test
+    void getOffset_defaultZeroValues() throws Exception {
+        when(immerManagerData.getOffsetX()).thenReturn(0);
+        when(immerManagerData.getOffsetY()).thenReturn(0);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/ImmerManager"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.offsetX").value(0))
+                .andExpect(jsonPath("$.offsetY").value(0));
+    }
+
+    @Test
+    void setOffset_updatesAndReturnsValues() throws Exception {
+        when(immerManagerData.getOffsetX()).thenReturn(7);
+        when(immerManagerData.getOffsetY()).thenReturn(3);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/ImmerManager/set")
+                        .param("x", "7")
+                        .param("y", "3"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.offsetX").value(7))
+                .andExpect(jsonPath("$.offsetY").value(3));
+
+        verify(immerManagerData).setOffsetX(7);
+        verify(immerManagerData).setOffsetY(3);
+    }
+
+    @Test
+    void setOffset_negativeValues() throws Exception {
+        when(immerManagerData.getOffsetX()).thenReturn(-5);
+        when(immerManagerData.getOffsetY()).thenReturn(-10);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/ImmerManager/set")
+                        .param("x", "-5")
+                        .param("y", "-10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.offsetX").value(-5))
+                .andExpect(jsonPath("$.offsetY").value(-10));
+
+        verify(immerManagerData).setOffsetX(-5);
+        verify(immerManagerData).setOffsetY(-10);
+    }
+
+    @Test
+    void setOffset_missingParamReturnsBadRequest() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/ImmerManager/set")
+                        .param("x", "5"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/keroleap/immerreader/SharedData/AristonManagerDataTest.java
+++ b/src/test/java/com/keroleap/immerreader/SharedData/AristonManagerDataTest.java
@@ -4,16 +4,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class ImmerOffsetDataTest {
+class AristonManagerDataTest {
 
     /**
-     * Directly instantiates ImmerOffsetData without a Spring context.
+     * Directly instantiates AristonManagerData without a Spring context.
      * The @PostConstruct (load) is not invoked, but the AtomicInteger fields
      * are initialised to 0 by their field declarations, so default-value
      * assertions are still meaningful.
      */
-    private ImmerOffsetData newInstance() {
-        return new ImmerOffsetData();
+    private AristonManagerData newInstance() {
+        return new AristonManagerData();
     }
 
     @Test
@@ -28,38 +28,35 @@ class ImmerOffsetDataTest {
 
     @Test
     void setAndGetOffsetX() {
-        ImmerOffsetData data = newInstance();
-        // save() will attempt to write to /data/offset.properties; it fails
-        // silently when the directory does not exist, so the in-memory value
-        // must still be updated.
+        AristonManagerData data = newInstance();
         data.setOffsetX(15);
         assertEquals(15, data.getOffsetX());
     }
 
     @Test
     void setAndGetOffsetY() {
-        ImmerOffsetData data = newInstance();
+        AristonManagerData data = newInstance();
         data.setOffsetY(30);
         assertEquals(30, data.getOffsetY());
     }
 
     @Test
     void setOffsetXToNegative() {
-        ImmerOffsetData data = newInstance();
+        AristonManagerData data = newInstance();
         data.setOffsetX(-5);
         assertEquals(-5, data.getOffsetX());
     }
 
     @Test
     void setOffsetYToNegative() {
-        ImmerOffsetData data = newInstance();
+        AristonManagerData data = newInstance();
         data.setOffsetY(-10);
         assertEquals(-10, data.getOffsetY());
     }
 
     @Test
     void setOffsetXMultipleTimes() {
-        ImmerOffsetData data = newInstance();
+        AristonManagerData data = newInstance();
         data.setOffsetX(10);
         data.setOffsetX(20);
         data.setOffsetX(5);
@@ -68,7 +65,7 @@ class ImmerOffsetDataTest {
 
     @Test
     void xAndYAreIndependent() {
-        ImmerOffsetData data = newInstance();
+        AristonManagerData data = newInstance();
         data.setOffsetX(7);
         data.setOffsetY(13);
         assertEquals(7, data.getOffsetX());

--- a/src/test/java/com/keroleap/immerreader/SharedData/ImmerManagerDataTest.java
+++ b/src/test/java/com/keroleap/immerreader/SharedData/ImmerManagerDataTest.java
@@ -1,0 +1,77 @@
+package com.keroleap.immerreader.SharedData;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ImmerManagerDataTest {
+
+    /**
+     * Directly instantiates ImmerManagerData without a Spring context.
+     * The @PostConstruct (load) is not invoked, but the AtomicInteger fields
+     * are initialised to 0 by their field declarations, so default-value
+     * assertions are still meaningful.
+     */
+    private ImmerManagerData newInstance() {
+        return new ImmerManagerData();
+    }
+
+    @Test
+    void defaultOffsetXIsZero() {
+        assertEquals(0, newInstance().getOffsetX());
+    }
+
+    @Test
+    void defaultOffsetYIsZero() {
+        assertEquals(0, newInstance().getOffsetY());
+    }
+
+    @Test
+    void setAndGetOffsetX() {
+        ImmerManagerData data = newInstance();
+        // save() will attempt to write to /data/offset.properties; it fails
+        // silently when the directory does not exist, so the in-memory value
+        // must still be updated.
+        data.setOffsetX(15);
+        assertEquals(15, data.getOffsetX());
+    }
+
+    @Test
+    void setAndGetOffsetY() {
+        ImmerManagerData data = newInstance();
+        data.setOffsetY(30);
+        assertEquals(30, data.getOffsetY());
+    }
+
+    @Test
+    void setOffsetXToNegative() {
+        ImmerManagerData data = newInstance();
+        data.setOffsetX(-5);
+        assertEquals(-5, data.getOffsetX());
+    }
+
+    @Test
+    void setOffsetYToNegative() {
+        ImmerManagerData data = newInstance();
+        data.setOffsetY(-10);
+        assertEquals(-10, data.getOffsetY());
+    }
+
+    @Test
+    void setOffsetXMultipleTimes() {
+        ImmerManagerData data = newInstance();
+        data.setOffsetX(10);
+        data.setOffsetX(20);
+        data.setOffsetX(5);
+        assertEquals(5, data.getOffsetX());
+    }
+
+    @Test
+    void xAndYAreIndependent() {
+        ImmerManagerData data = newInstance();
+        data.setOffsetX(7);
+        data.setOffsetY(13);
+        assertEquals(7, data.getOffsetX());
+        assertEquals(13, data.getOffsetY());
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements a complete web UI refactor with the following changes:

### 1. ImmerManager Refactor
- Renamed `ImmerOffsetController` → `ImmerManagerController`
- Renamed `ImmerOffsetData` → `ImmerManagerData`
- Renamed `offset-adjuster.html` → `immer-manager.html`
- Updated all related tests and scheduler references

### 2. AristonManager Creation
- Created `AristonManagerController` with offset adjustment endpoints
- Created `AristonManagerData` with persistent storage
- Created `ariston-manager.html` template with live preview

### 3. Main Navigation
- Created `index.html` at `/` as the home page
- Added navigation menu to all pages (Home, Immer Manager, Ariston Manager)
- Consistent styling across all pages with dark theme

## Files Changed
- **Controllers**: `ImmerManagerController`, `AristonManagerController`
- **Data**: `ImmerManagerData`, `AristonManagerData`
- **Templates**: `index.html`, `immer-manager.html`, `ariston-manager.html`
- **Tests**: Full test coverage for all new components

## Test Plan
- Run `mvn test` to verify all tests pass
- Navigate to `/` to see the main page
- Test offset adjustment on both manager pages
- Verify live image preview updates correctly