### PR TITLE
Add detected data display with graphs to manager views

### DIFF
--- a/src/main/java/com/keroleap/immerreader/Controller/AristonManagerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/AristonManagerController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
-import com.keroleap.immerreader.AristonRest;
 import com.keroleap.immerreader.SharedData.AristonData;
 import com.keroleap.immerreader.SharedData.AristonManagerData;
 

--- a/src/main/java/com/keroleap/immerreader/Controller/AristonManagerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/AristonManagerController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
+import com.keroleap.immerreader.AristonRest;
+import com.keroleap.immerreader.SharedData.AristonData;
 import com.keroleap.immerreader.SharedData.AristonManagerData;
 
 @Controller
@@ -17,6 +19,9 @@ public class AristonManagerController {
 
     @Autowired
     private AristonManagerData aristonManagerData;
+
+    @Autowired
+    private AristonData aristonData;
 
     @PostMapping("/set")
     @ResponseBody
@@ -37,6 +42,7 @@ public class AristonManagerController {
         ModelAndView modelAndView = new ModelAndView("ariston-manager");
         modelAndView.addObject("offsetX", aristonManagerData.getOffsetX());
         modelAndView.addObject("offsetY", aristonManagerData.getOffsetY());
+        modelAndView.addObject("aristonRest", aristonData.getAristonRest());
         return modelAndView;
     }
 }

--- a/src/main/java/com/keroleap/immerreader/Controller/ImmerManagerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/ImmerManagerController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
+import com.keroleap.immerreader.ImmerRest;
+import com.keroleap.immerreader.SharedData.ImmerData;
 import com.keroleap.immerreader.SharedData.ImmerManagerData;
 
 @Controller
@@ -17,6 +19,9 @@ public class ImmerManagerController {
 
     @Autowired
     private ImmerManagerData immerManagerData;
+
+    @Autowired
+    private ImmerData immerData;
 
     @PostMapping("/set")
     @ResponseBody
@@ -37,6 +42,7 @@ public class ImmerManagerController {
         ModelAndView modelAndView = new ModelAndView("immer-manager");
         modelAndView.addObject("offsetX", immerManagerData.getOffsetX());
         modelAndView.addObject("offsetY", immerManagerData.getOffsetY());
+        modelAndView.addObject("immerRest", immerData.getImmerRest());
         return modelAndView;
     }
 }

--- a/src/main/java/com/keroleap/immerreader/Controller/ImmerManagerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/ImmerManagerController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
-import com.keroleap.immerreader.ImmerRest;
 import com.keroleap.immerreader.SharedData.ImmerData;
 import com.keroleap.immerreader.SharedData.ImmerManagerData;
 

--- a/src/main/resources/templates/ariston-manager.html
+++ b/src/main/resources/templates/ariston-manager.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Ariston Manager</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         * {
             box-sizing: border-box;
@@ -37,6 +38,7 @@
             gap: 20px;
             align-items: flex-start;
             padding: 0 20px;
+            flex-wrap: wrap;
         }
         .controls {
             background: #16213e;
@@ -103,6 +105,44 @@
         h1 {
             padding: 0 20px;
         }
+        .data-section {
+            background: #16213e;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+        .data-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 15px;
+            margin-top: 15px;
+        }
+        .data-card {
+            background: #0f3460;
+            padding: 15px;
+            border-radius: 8px;
+            text-align: center;
+        }
+        .data-card h3 {
+            margin: 0 0 10px 0;
+            color: #aaa;
+            font-size: 14px;
+        }
+        .data-card .value {
+            font-size: 24px;
+            font-weight: bold;
+            color: #e94560;
+        }
+        .chart-container {
+            background: #16213e;
+            padding: 20px;
+            border-radius: 8px;
+            margin-top: 20px;
+            height: 300px;
+        }
+        .full-width {
+            width: 100%;
+        }
     </style>
 </head>
 <body>
@@ -113,6 +153,18 @@
     </nav>
 
     <h1>Ariston Manager</h1>
+
+    <div style="padding: 0 20px;">
+        <div class="data-section">
+            <h2>Detected Data</h2>
+            <div class="data-grid">
+                <div class="data-card">
+                    <h3>Power Level</h3>
+                    <div class="value"><span id="percentage" th:text="${aristonRest.percentage}">0</span>%</div>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <div class="container">
         <div class="controls">
@@ -141,6 +193,15 @@
             <h2>Live Preview</h2>
             <img id="liveImage" src="/Ariston/uncroppedimage" alt="Ariston Camera Feed">
             <p><small>Image refreshes automatically every 15 seconds</small></p>
+        </div>
+    </div>
+
+    <div style="padding: 0 20px;">
+        <div class="data-section full-width">
+            <h2>Power Level History</h2>
+            <div class="chart-container">
+                <canvas id="percentageChart"></canvas>
+            </div>
         </div>
     </div>
 
@@ -183,6 +244,79 @@
         }
 
         setInterval(refreshImage, 15000);
+
+        // Data polling and chart
+        const percentageCtx = document.getElementById('percentageChart').getContext('2d');
+        const percentageChart = new Chart(percentageCtx, {
+            type: 'line',
+            data: {
+                labels: [],
+                datasets: [{
+                    label: 'Power Level (%)',
+                    data: [],
+                    borderColor: '#e94560',
+                    backgroundColor: 'rgba(233, 69, 96, 0.1)',
+                    borderWidth: 2,
+                    fill: true,
+                    tension: 0.4
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        max: 100,
+                        ticks: {
+                            color: '#eee'
+                        },
+                        grid: {
+                            color: '#0f3460'
+                        }
+                    },
+                    x: {
+                        ticks: {
+                            color: '#eee'
+                        },
+                        grid: {
+                            color: '#0f3460'
+                        }
+                    }
+                },
+                plugins: {
+                    legend: {
+                        labels: {
+                            color: '#eee'
+                        }
+                    }
+                }
+            }
+        });
+
+        function updateData() {
+            fetch('/Ariston/aristonrestdata')
+                .then(response => response.json())
+                .then(data => {
+                    document.getElementById('percentage').textContent = data.percentage;
+
+                    const now = new Date().toLocaleTimeString();
+                    percentageChart.data.labels.push(now);
+                    percentageChart.data.datasets[0].data.push(data.percentage);
+
+                    if (percentageChart.data.labels.length > 30) {
+                        percentageChart.data.labels.shift();
+                        percentageChart.data.datasets[0].data.shift();
+                    }
+                    percentageChart.update();
+                })
+                .catch(error => {
+                    console.error('Error fetching data:', error);
+                });
+        }
+
+        setInterval(updateData, 15000);
+        updateData();
     </script>
 </body>
 </html>

--- a/src/main/resources/templates/immer-manager.html
+++ b/src/main/resources/templates/immer-manager.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Immer Manager</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         * {
             box-sizing: border-box;
@@ -37,6 +38,7 @@
             gap: 20px;
             align-items: flex-start;
             padding: 0 20px;
+            flex-wrap: wrap;
         }
         .controls {
             background: #16213e;
@@ -103,6 +105,47 @@
         h1 {
             padding: 0 20px;
         }
+        .data-section {
+            background: #16213e;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+        .data-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 15px;
+            margin-top: 15px;
+        }
+        .data-card {
+            background: #0f3460;
+            padding: 15px;
+            border-radius: 8px;
+            text-align: center;
+        }
+        .data-card h3 {
+            margin: 0 0 10px 0;
+            color: #aaa;
+            font-size: 14px;
+        }
+        .data-card .value {
+            font-size: 24px;
+            font-weight: bold;
+            color: #e94560;
+        }
+        .data-card .value.active {
+            color: #28a745;
+        }
+        .chart-container {
+            background: #16213e;
+            padding: 20px;
+            border-radius: 8px;
+            margin-top: 20px;
+            height: 300px;
+        }
+        .full-width {
+            width: 100%;
+        }
     </style>
 </head>
 <body>
@@ -113,6 +156,30 @@
     </nav>
 
     <h1>Immer Manager</h1>
+
+    <div style="padding: 0 20px;">
+        <div class="data-section">
+            <h2>Detected Data</h2>
+            <div class="data-grid">
+                <div class="data-card">
+                    <h3>Temperature</h3>
+                    <div class="value"><span id="temperature" th:text="${immerRest.temperaute}">0</span>°C</div>
+                </div>
+                <div class="data-card">
+                    <h3>Throttle Level</h3>
+                    <div class="value"><span id="throttle" th:text="${immerRest.throttle}">0</span>/4</div>
+                </div>
+                <div class="data-card">
+                    <h3>Heating</h3>
+                    <div class="value" id="heating" th:classappend="${immerRest.heating} ? 'active' : ''" th:text="${immerRest.heating} ? 'ON' : 'OFF'">OFF</div>
+                </div>
+                <div class="data-card">
+                    <h3>Boiler</h3>
+                    <div class="value" id="boiler" th:classappend="${immerRest.boilerOn} ? 'active' : ''" th:text="${immerRest.boilerOn} ? 'ON' : 'OFF'">OFF</div>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <div class="container">
         <div class="controls">
@@ -141,6 +208,15 @@
             <h2>Live Preview</h2>
             <img id="liveImage" src="/Immer/uncroppedimage" alt="Immer Camera Feed">
             <p><small>Image refreshes automatically every 2 seconds</small></p>
+        </div>
+    </div>
+
+    <div style="padding: 0 20px;">
+        <div class="data-section full-width">
+            <h2>Temperature History</h2>
+            <div class="chart-container">
+                <canvas id="temperatureChart"></canvas>
+            </div>
         </div>
     </div>
 
@@ -183,6 +259,85 @@
         }
 
         setInterval(refreshImage, 2000);
+
+        // Data polling and chart
+        const temperatureCtx = document.getElementById('temperatureChart').getContext('2d');
+        const temperatureChart = new Chart(temperatureCtx, {
+            type: 'line',
+            data: {
+                labels: [],
+                datasets: [{
+                    label: 'Temperature (°C)',
+                    data: [],
+                    borderColor: '#e94560',
+                    backgroundColor: 'rgba(233, 69, 96, 0.1)',
+                    borderWidth: 2,
+                    fill: true,
+                    tension: 0.4
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    y: {
+                        beginAtZero: false,
+                        min: 15,
+                        max: 60,
+                        ticks: {
+                            color: '#eee'
+                        },
+                        grid: {
+                            color: '#0f3460'
+                        }
+                    },
+                    x: {
+                        ticks: {
+                            color: '#eee'
+                        },
+                        grid: {
+                            color: '#0f3460'
+                        }
+                    }
+                },
+                plugins: {
+                    legend: {
+                        labels: {
+                            color: '#eee'
+                        }
+                    }
+                }
+            }
+        });
+
+        function updateData() {
+            fetch('/Immer/immerrestdata')
+                .then(response => response.json())
+                .then(data => {
+                    document.getElementById('temperature').textContent = data.temperaute;
+                    document.getElementById('throttle').textContent = data.throttle;
+                    document.getElementById('heating').textContent = data.heating ? 'ON' : 'OFF';
+                    document.getElementById('heating').className = 'value ' + (data.heating ? 'active' : '');
+                    document.getElementById('boiler').textContent = data.boilerOn ? 'ON' : 'OFF';
+                    document.getElementById('boiler').className = 'value ' + (data.boilerOn ? 'active' : '');
+
+                    const now = new Date().toLocaleTimeString();
+                    temperatureChart.data.labels.push(now);
+                    temperatureChart.data.datasets[0].data.push(data.temperaute);
+
+                    if (temperatureChart.data.labels.length > 30) {
+                        temperatureChart.data.labels.shift();
+                        temperatureChart.data.datasets[0].data.shift();
+                    }
+                    temperatureChart.update();
+                })
+                .catch(error => {
+                    console.error('Error fetching data:', error);
+                });
+        }
+
+        setInterval(updateData, 2000);
+        updateData();
     </script>
 </body>
 </html>

--- a/src/test/java/com/keroleap/immerreader/Controller/AristonManagerControllerTest.java
+++ b/src/test/java/com/keroleap/immerreader/Controller/AristonManagerControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import com.keroleap.immerreader.SharedData.AristonData;
 import com.keroleap.immerreader.SharedData.AristonManagerData;
 
 import static org.mockito.Mockito.when;
@@ -22,6 +23,9 @@ class AristonManagerControllerTest {
 
     @MockitoBean
     private AristonManagerData aristonManagerData;
+
+    @MockitoBean
+    private AristonData aristonData;
 
     @Test
     void getOffset_returnsCurrentValues() throws Exception {

--- a/src/test/java/com/keroleap/immerreader/Controller/ImmerManagerControllerTest.java
+++ b/src/test/java/com/keroleap/immerreader/Controller/ImmerManagerControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import com.keroleap.immerreader.SharedData.ImmerData;
 import com.keroleap.immerreader.SharedData.ImmerManagerData;
 
 import static org.mockito.Mockito.when;
@@ -22,6 +23,9 @@ class ImmerManagerControllerTest {
 
     @MockitoBean
     private ImmerManagerData immerManagerData;
+
+    @MockitoBean
+    private ImmerData immerData;
 
     @Test
     void getOffset_returnsCurrentValues() throws Exception {


### PR DESCRIPTION
## Summary

Adds real-time detected data display and historical graphs to both Immer and Ariston manager views.

## Features

### Immer Manager
- **Data Cards**: Temperature (°C), Throttle Level (1-4), Heating (ON/OFF), Boiler (ON/OFF)
- **Temperature Graph**: Real-time line chart showing last 30 readings (updates every 2 seconds)
- **Status Indicators**: Active states highlighted in green for ON conditions

### Ariston Manager
- **Data Cards**: Power Level (0-100%)
- **Power Level Graph**: Real-time line chart showing last 30 readings (updates every 15 seconds)

## Implementation

- Uses Chart.js for interactive graphs
- Polls REST endpoints (`/Immer/immerrestdata`, `/Ariston/aristonrestdata`) for live data
- Graphs maintain a rolling window of 30 data points with timestamps
- Responsive grid layout for data cards
- Consistent dark theme styling across both views

## Screenshots

The manager views now display:
1. Detected sensor data in card format at the top
2. Offset controls and live camera preview below
3. Historical temperature/power graph at the bottom