### PR TITLE
Add unknown digit error tracking and improve layout

### DIFF
--- a/src/main/java/com/keroleap/immerreader/Service/ImmerAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/ImmerAnalyzerService.java
@@ -13,9 +13,11 @@ import javax.imageio.ImageIO;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.keroleap.immerreader.ImmerRest;
+import com.keroleap.immerreader.SharedData.ErrorStatistics;
 
 @Service
 public class ImmerAnalyzerService {
@@ -23,6 +25,9 @@ public class ImmerAnalyzerService {
     private static final Logger logger = LoggerFactory.getLogger(ImmerAnalyzerService.class);
     private static final int LIGHT_THRESHOLD = -2500000;
     private final AtomicInteger previousTempValue = new AtomicInteger(0);
+
+    @Autowired(required = false)
+    private ErrorStatistics errorStatistics;
 
     public ImmerRest getImmerRestData(BufferedImage bufferedImage, int offsetX, int offsetY) {
         boolean heating = getLightValueAnnDrawRedCross(495 + offsetX, 215 + offsetY, bufferedImage);
@@ -123,6 +128,9 @@ public class ImmerAnalyzerService {
         }
         if (number == 1000) {
             logger.warn("Unknown digit detected: {}{}{}{}{}{}{}", digit1_1, digit1_2, digit1_3, digit1_4, digit1_5, digit1_6, digit1_7);
+            if (errorStatistics != null) {
+                errorStatistics.recordError("Immer", "unknown_digit");
+            }
         }
         return number;
     }

--- a/src/main/resources/templates/immer-manager.html
+++ b/src/main/resources/templates/immer-manager.html
@@ -157,6 +157,20 @@
             font-weight: bold;
             color: #e94560;
         }
+        .main-content {
+            display: flex;
+            gap: 20px;
+            padding: 0 20px;
+            flex-wrap: wrap;
+        }
+        .left-panel {
+            flex: 1;
+            min-width: 300px;
+        }
+        .right-panel {
+            flex: 1;
+            min-width: 300px;
+        }
     </style>
 </head>
 <body>
@@ -191,22 +205,11 @@
             </div>
         </div>
 
-        <div class="data-section">
-            <h2>Error Statistics (Last 24 Hours)</h2>
-            <div class="error-stats">
-                <div class="error-card">
-                    <h4>Timeout Errors</h4>
-                    <div class="count"><span id="timeoutErrors" th:text="${errorStats['timeout']} ?: 0">0</span></div>
-                </div>
-                <div class="error-card">
-                    <h4>General Errors</h4>
-                    <div class="count"><span id="generalErrors" th:text="${errorStats['error']} ?: 0">0</span></div>
-                </div>
-            </div>
-        </div>
     </div>
 
-    <div class="container">
+    <div class="main-content">
+        <div class="left-panel">
+            <div class="container">
         <div class="controls">
             <form id="offsetForm">
                 <div class="form-group">
@@ -233,6 +236,28 @@
             <h2>Live Preview</h2>
             <img id="liveImage" src="/Immer/uncroppedimage" alt="Immer Camera Feed">
             <p><small>Image refreshes automatically every 2 seconds</small></p>
+        </div>
+            </div>
+        </div>
+
+        <div class="right-panel">
+            <div class="data-section">
+                <h2>Error Statistics (Last 24 Hours)</h2>
+                <div class="error-stats">
+                    <div class="error-card">
+                        <h4>Timeout Errors</h4>
+                        <div class="count"><span id="timeoutErrors" th:text="${errorStats['timeout']} ?: 0">0</span></div>
+                    </div>
+                    <div class="error-card">
+                        <h4>General Errors</h4>
+                        <div class="count"><span id="generalErrors" th:text="${errorStats['error']} ?: 0">0</span></div>
+                    </div>
+                    <div class="error-card">
+                        <h4>Unknown Digit</h4>
+                        <div class="count"><span id="unknownDigitErrors" th:text="${errorStats['unknown_digit']} ?: 0">0</span></div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
Adds unknown digit error tracking for Immer system and improves the error statistics layout.

## Changes
- **ImmerAnalyzerService**: Records "unknown_digit" error when 7-segment display cannot be decoded
- **Layout**: Moved error statistics to the right side of the camera view
- **New error type**: Unknown Digit errors displayed alongside Timeout and General errors

## UI Changes
Error statistics now appear in a right panel next to the camera view instead of below the data section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)