### PR TITLE
Add Spring Security with H2 database authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,19 @@
  		<groupId>org.springframework.boot</groupId>
  		<artifactId>spring-boot-starter-actuator</artifactId>
  	</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/keroleap/immerreader/CustomUserDetailsService.java
+++ b/src/main/java/com/keroleap/immerreader/CustomUserDetailsService.java
@@ -1,0 +1,35 @@
+package com.keroleap.immerreader;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+        return new org.springframework.security.core.userdetails.User(
+                user.getUsername(),
+                user.getPassword(),
+                user.isEnabled(),
+                true,
+                true,
+                true,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/DataInitializer.java
+++ b/src/main/java/com/keroleap/immerreader/DataInitializer.java
@@ -1,0 +1,29 @@
+package com.keroleap.immerreader;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataInitializer implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public DataInitializer(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public void run(String... args) {
+        if (!userRepository.findByUsername("admin").isPresent()) {
+            User adminUser = new User(
+                    "admin",
+                    passwordEncoder.encode("admin123"),
+                    true
+            );
+            userRepository.save(adminUser);
+        }
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/SecurityConfig.java
+++ b/src/main/java/com/keroleap/immerreader/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.keroleap.immerreader;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final CustomUserDetailsService userDetailsService;
+
+    public SecurityConfig(CustomUserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf
+                .ignoringRequestMatchers("/h2-console/**")
+            )
+            .headers(headers -> headers
+                .frameOptions(frame -> frame.disable())
+            )
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/h2-console/**").authenticated()
+                .anyRequest().authenticated()
+            )
+            .formLogin(form -> form
+                .permitAll()
+                .defaultSuccessUrl("/", true)
+            )
+            .logout(logout -> logout
+                .permitAll()
+                .logoutSuccessUrl("/login?logout")
+            );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/User.java
+++ b/src/main/java/com/keroleap/immerreader/User.java
@@ -1,0 +1,62 @@
+package com.keroleap.immerreader;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    public User() {
+    }
+
+    public User(String username, String password, boolean enabled) {
+        this.username = username;
+        this.password = password;
+        this.enabled = enabled;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/UserRepository.java
+++ b/src/main/java/com/keroleap/immerreader/UserRepository.java
@@ -1,0 +1,11 @@
+package com.keroleap.immerreader;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 server.port=8099
+spring.datasource.url=jdbc:h2:file:/data/immerreader
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console


### PR DESCRIPTION
## Summary
Implements authentication and authorization using Spring Security with H2 database-backed user storage.

## Changes
- **Dependencies**: Added `spring-boot-starter-security`, `spring-boot-starter-data-jpa`, and `h2`
- **User Entity**: JPA entity for storing user credentials with BCrypt password hashing
- **Security Configuration**: Form-based login, CSRF protection, session-based authentication
- **Default User**: Auto-creates `admin` / `admin123` on first startup
- **H2 Console**: Enabled at `/h2-console` for database management

## Security Features
✅ All endpoints require authentication
✅ Password encryption with BCrypt
✅ Persistent user database at `/data/immerreader.mv.db`
✅ CSRF protection enabled
✅ H2 console accessible for user management

## Default Credentials
- **Username**: `admin`
- **Password**: `admin123`

## Testing
- Build successful: `mvn clean package -DskipTests`
- Default admin user created on application startup
- Login page available at `/login`