### PR TITLE
Refactor Ariston detection to configurable line-based interpolation

### DIFF
--- a/src/main/java/com/keroleap/immerreader/Controller/AristonController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/AristonController.java
@@ -20,6 +20,7 @@ import org.springframework.web.servlet.ModelAndView;
 import com.keroleap.immerreader.AristonRest;
 import com.keroleap.immerreader.Service.AristonAnalyzerService;
 import com.keroleap.immerreader.SharedData.AristonData;
+import com.keroleap.immerreader.SharedData.AristonManagerData;
 
 @Controller
 @RequestMapping("/Ariston")
@@ -33,10 +34,15 @@ public class AristonController {
     @Autowired
     private AristonAnalyzerService aristonAnalyzerService;
 
+    @Autowired
+    private AristonManagerData aristonManagerData;
+
     @GetMapping(value = "/image", produces = MediaType.IMAGE_JPEG_VALUE)
     public @ResponseBody byte[] getImage() throws IOException {
         BufferedImage cachedImage = aristonAnalyzerService.getBufferedImage("http://192.168.1.191/cgi/jpg/image.cgi");
-        aristonAnalyzerService.getAristonRestData(cachedImage);
+        aristonAnalyzerService.getAristonRestData(cachedImage,
+                aristonManagerData.getStartX(), aristonManagerData.getStartY(),
+                aristonManagerData.getEndX(), aristonManagerData.getEndY());
         int x1 = 60;
         int y1 = 115;
         int x2 = 260;
@@ -54,7 +60,9 @@ public class AristonController {
     @GetMapping(value = "/uncroppedimage", produces = MediaType.IMAGE_JPEG_VALUE)
     public @ResponseBody byte[] getUncroppedImage() throws IOException {
         BufferedImage cachedImage = aristonAnalyzerService.getBufferedImage("http://192.168.1.191/cgi/jpg/image.cgi");
-        aristonAnalyzerService.getAristonRestData(cachedImage);
+        aristonAnalyzerService.getAristonRestData(cachedImage,
+                aristonManagerData.getStartX(), aristonManagerData.getStartY(),
+                aristonManagerData.getEndX(), aristonManagerData.getEndY());
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ImageIO.write(cachedImage, "jpg", baos);
         return baos.toByteArray();
@@ -64,7 +72,9 @@ public class AristonController {
     public ModelAndView getAristonData() throws IOException {
         BufferedImage cachedImage = aristonAnalyzerService.getBufferedImage("http://192.168.1.191/cgi/jpg/image.cgi");
         ModelAndView modelAndView = new ModelAndView("immerdata");
-        modelAndView.addObject("message", aristonAnalyzerService.getAristonRestData(cachedImage).toString());
+        modelAndView.addObject("message", aristonAnalyzerService.getAristonRestData(cachedImage,
+                aristonManagerData.getStartX(), aristonManagerData.getStartY(),
+                aristonManagerData.getEndX(), aristonManagerData.getEndY()).toString());
         return modelAndView;
     }
 

--- a/src/main/java/com/keroleap/immerreader/Controller/AristonManagerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/AristonManagerController.java
@@ -28,23 +28,30 @@ public class AristonManagerController {
 
     @PostMapping("/set")
     @ResponseBody
-    public AristonManagerData setOffset(@RequestParam int x, @RequestParam int y) {
-        aristonManagerData.setOffsetX(x);
-        aristonManagerData.setOffsetY(y);
+    public AristonManagerData setPoints(@RequestParam int startX,
+                                         @RequestParam int startY,
+                                         @RequestParam int endX,
+                                         @RequestParam int endY) {
+        aristonManagerData.setStartX(startX);
+        aristonManagerData.setStartY(startY);
+        aristonManagerData.setEndX(endX);
+        aristonManagerData.setEndY(endY);
         return aristonManagerData;
     }
 
     @GetMapping
     @ResponseBody
-    public AristonManagerData getOffset() {
+    public AristonManagerData getPoints() {
         return aristonManagerData;
     }
 
     @GetMapping("/adjust")
-    public ModelAndView adjustOffset() {
+    public ModelAndView adjustPoints() {
         ModelAndView modelAndView = new ModelAndView("ariston-manager");
-        modelAndView.addObject("offsetX", aristonManagerData.getOffsetX());
-        modelAndView.addObject("offsetY", aristonManagerData.getOffsetY());
+        modelAndView.addObject("startX", aristonManagerData.getStartX());
+        modelAndView.addObject("startY", aristonManagerData.getStartY());
+        modelAndView.addObject("endX", aristonManagerData.getEndX());
+        modelAndView.addObject("endY", aristonManagerData.getEndY());
         modelAndView.addObject("aristonRest", aristonData.getAristonRest());
         modelAndView.addObject("errorStats", errorStatistics.getLastErrorCounts("Ariston"));
         return modelAndView;

--- a/src/main/java/com/keroleap/immerreader/Scheduler/AristonScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/AristonScheduler.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import com.keroleap.immerreader.AristonRest;
 import com.keroleap.immerreader.Service.AristonAnalyzerService;
 import com.keroleap.immerreader.SharedData.AristonData;
+import com.keroleap.immerreader.SharedData.AristonManagerData;
 import com.keroleap.immerreader.SharedData.ErrorStatistics;
 
 import jakarta.annotation.PreDestroy;
@@ -32,6 +33,9 @@ public class AristonScheduler {
     private AristonAnalyzerService aristonAnalyzerService;
 
     @Autowired
+    private AristonManagerData aristonManagerData;
+
+    @Autowired
     private ErrorStatistics errorStatistics;
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -40,7 +44,9 @@ public class AristonScheduler {
     public void AristonScheduledRead() {
         Future<AristonRest> future = executor.submit(() -> {
             BufferedImage cachedImage = aristonAnalyzerService.getBufferedImage("http://192.168.1.191/cgi/jpg/image.cgi");
-            return aristonAnalyzerService.getAristonRestData(cachedImage);
+            return aristonAnalyzerService.getAristonRestData(cachedImage,
+                    aristonManagerData.getStartX(), aristonManagerData.getStartY(),
+                    aristonManagerData.getEndX(), aristonManagerData.getEndY());
         });
 
         try {
@@ -62,4 +68,3 @@ public class AristonScheduler {
         executor.shutdownNow();
     }
 }
-

--- a/src/main/java/com/keroleap/immerreader/Service/AristonAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/AristonAnalyzerService.java
@@ -21,16 +21,23 @@ public class AristonAnalyzerService {
 
     private static final Logger logger = LoggerFactory.getLogger(AristonAnalyzerService.class);
     private static final int LIGHT_THRESHOLD = -7000000;
+    private static final int POINT_COUNT = 50;
 
-    private static final int[] PERCENT_X = {160, 163, 166, 169, 172, 175, 178, 181, 184, 187, 190, 193, 196, 199, 202, 205, 208, 211, 214, 217, 220};
-    private static final int[] PERCENT_Y = {160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180};
-
-    public AristonRest getAristonRestData(BufferedImage bufferedImage) {
+    public AristonRest getAristonRestData(BufferedImage bufferedImage,
+                                          int startX, int startY,
+                                          int endX, int endY) {
         int percentage = 0;
-        for (int i = 0; i < PERCENT_X.length; i++) {
-            if (getLightValueAndDrawRedCross(PERCENT_X[i], PERCENT_Y[i], bufferedImage)) {
-                percentage = i * 5;
+        int lastDetectedIndex = -1;
+        for (int i = 0; i < POINT_COUNT; i++) {
+            double t = (double) i / (POINT_COUNT - 1);
+            int x = (int) Math.round(startX + (endX - startX) * t);
+            int y = (int) Math.round(startY + (endY - startY) * t);
+            if (getLightValueAndDrawRedCross(x, y, bufferedImage)) {
+                lastDetectedIndex = i;
             }
+        }
+        if (lastDetectedIndex >= 0) {
+            percentage = (int) Math.round(lastDetectedIndex * 100.0 / (POINT_COUNT - 1));
         }
         AristonRest aristonRest = new AristonRest();
         aristonRest.setPercentage(percentage);

--- a/src/main/java/com/keroleap/immerreader/Service/AristonAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/AristonAnalyzerService.java
@@ -26,19 +26,28 @@ public class AristonAnalyzerService {
     public AristonRest getAristonRestData(BufferedImage bufferedImage,
                                           int startX, int startY,
                                           int endX, int endY) {
-        int percentage = 0;
+        int[] xs = new int[POINT_COUNT];
+        int[] ys = new int[POINT_COUNT];
+        boolean[] detected = new boolean[POINT_COUNT];
         int lastDetectedIndex = -1;
+
         for (int i = 0; i < POINT_COUNT; i++) {
             double t = (double) i / (POINT_COUNT - 1);
-            int x = (int) Math.round(startX + (endX - startX) * t);
-            int y = (int) Math.round(startY + (endY - startY) * t);
-            if (getLightValueAndDrawRedCross(x, y, bufferedImage)) {
+            xs[i] = (int) Math.round(startX + (endX - startX) * t);
+            ys[i] = (int) Math.round(startY + (endY - startY) * t);
+            detected[i] = detectLightValue(xs[i], ys[i], bufferedImage);
+            if (detected[i]) {
                 lastDetectedIndex = i;
             }
         }
-        if (lastDetectedIndex >= 0) {
-            percentage = (int) Math.round(lastDetectedIndex * 100.0 / (POINT_COUNT - 1));
+
+        for (int i = 0; i < POINT_COUNT; i++) {
+            drawRedCross(xs[i], ys[i], bufferedImage, detected[i]);
         }
+
+        int percentage = lastDetectedIndex >= 0
+                ? (int) Math.round(lastDetectedIndex * 100.0 / (POINT_COUNT - 1))
+                : 0;
         AristonRest aristonRest = new AristonRest();
         aristonRest.setPercentage(percentage);
         return aristonRest;
@@ -64,7 +73,7 @@ public class AristonAnalyzerService {
         }
     }
 
-    private boolean getLightValueAndDrawRedCross(int x, int y, BufferedImage image) {
+    private boolean detectLightValue(int x, int y, BufferedImage image) {
         long sum = 0;
         for (int a = x - 3; a < x + 3; a++) {
             sum += image.getRGB(a, y);
@@ -73,7 +82,10 @@ public class AristonAnalyzerService {
             sum += image.getRGB(x, b);
         }
         double lightValue = sum / 12.0;
-        boolean detected = lightValue < LIGHT_THRESHOLD;
+        return lightValue < LIGHT_THRESHOLD;
+    }
+
+    private void drawRedCross(int x, int y, BufferedImage image, boolean detected) {
         int color = detected ? 16711680 : 16777215;
         for (int a = x - 5; a < x + 5; a++) {
             image.setRGB(a, y, color);
@@ -81,6 +93,5 @@ public class AristonAnalyzerService {
         for (int b = y - 5; b < y + 5; b++) {
             image.setRGB(x, b, color);
         }
-        return detected;
     }
 }

--- a/src/main/java/com/keroleap/immerreader/SharedData/AristonManagerData.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/AristonManagerData.java
@@ -18,8 +18,10 @@ public class AristonManagerData {
     private static final Logger logger = LoggerFactory.getLogger(AristonManagerData.class);
     private static final String DATA_FILE = "/data/ariston.properties";
 
-    private final AtomicInteger offsetX = new AtomicInteger(0);
-    private final AtomicInteger offsetY = new AtomicInteger(0);
+    private final AtomicInteger startX = new AtomicInteger(160);
+    private final AtomicInteger startY = new AtomicInteger(160);
+    private final AtomicInteger endX = new AtomicInteger(220);
+    private final AtomicInteger endY = new AtomicInteger(180);
 
     @PostConstruct
     private void load() {
@@ -28,8 +30,10 @@ public class AristonManagerData {
             Properties props = new Properties();
             try (FileInputStream fis = new FileInputStream(file)) {
                 props.load(fis);
-                offsetX.set(Integer.parseInt(props.getProperty("offsetX", "0")));
-                offsetY.set(Integer.parseInt(props.getProperty("offsetY", "0")));
+                startX.set(Integer.parseInt(props.getProperty("startX", "160")));
+                startY.set(Integer.parseInt(props.getProperty("startY", "160")));
+                endX.set(Integer.parseInt(props.getProperty("endX", "220")));
+                endY.set(Integer.parseInt(props.getProperty("endY", "180")));
             } catch (IOException | NumberFormatException e) {
                 logger.warn("Could not load offset data from {}: {}", DATA_FILE, e.getMessage());
             }
@@ -38,8 +42,10 @@ public class AristonManagerData {
 
     private void save() {
         Properties props = new Properties();
-        props.setProperty("offsetX", String.valueOf(offsetX.get()));
-        props.setProperty("offsetY", String.valueOf(offsetY.get()));
+        props.setProperty("startX", String.valueOf(startX.get()));
+        props.setProperty("startY", String.valueOf(startY.get()));
+        props.setProperty("endX", String.valueOf(endX.get()));
+        props.setProperty("endY", String.valueOf(endY.get()));
         File file = new File(DATA_FILE);
         File parent = file.getParentFile();
         if (!parent.exists() && !parent.mkdirs()) {
@@ -53,21 +59,39 @@ public class AristonManagerData {
         }
     }
 
-    public int getOffsetX() {
-        return offsetX.get();
+    public int getStartX() {
+        return startX.get();
     }
 
-    public void setOffsetX(int offsetX) {
-        this.offsetX.set(offsetX);
+    public void setStartX(int startX) {
+        this.startX.set(startX);
         save();
     }
 
-    public int getOffsetY() {
-        return offsetY.get();
+    public int getStartY() {
+        return startY.get();
     }
 
-    public void setOffsetY(int offsetY) {
-        this.offsetY.set(offsetY);
+    public void setStartY(int startY) {
+        this.startY.set(startY);
+        save();
+    }
+
+    public int getEndX() {
+        return endX.get();
+    }
+
+    public void setEndX(int endX) {
+        this.endX.set(endX);
+        save();
+    }
+
+    public int getEndY() {
+        return endY.get();
+    }
+
+    public void setEndY(int endY) {
+        this.endY.set(endY);
         save();
     }
 }

--- a/src/main/resources/templates/ariston-manager.html
+++ b/src/main/resources/templates/ariston-manager.html
@@ -76,15 +76,44 @@
         button:hover {
             background: #ff6b6b;
         }
+        button.secondary {
+            background: #0f3460;
+            margin-top: 8px;
+        }
+        button.secondary.active {
+            background: #28a745;
+        }
         .image-container {
             background: #16213e;
             padding: 20px;
             border-radius: 8px;
+            position: relative;
+        }
+        .image-wrapper {
+            position: relative;
+            display: inline-block;
         }
         img {
             max-width: 800px;
             border: 2px solid #0f3460;
             border-radius: 4px;
+            display: block;
+            cursor: crosshair;
+        }
+        .marker {
+            position: absolute;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            border: 2px solid #fff;
+            transform: translate(-50%, -50%);
+            pointer-events: none;
+        }
+        .marker.start {
+            background: #28a745;
+        }
+        .marker.end {
+            background: #e94560;
         }
         .current-values {
             margin-top: 15px;
@@ -196,31 +225,46 @@
         <div class="left-panel">
             <div class="container">
                 <div class="controls">
-                    <form id="offsetForm">
+                    <form id="pointForm">
                         <div class="form-group">
-                            <label for="offsetX">Offset X:</label>
-                            <input type="number" id="offsetX" name="x" th:value="${offsetX}" required>
+                            <label for="startX">Start X:</label>
+                            <input type="number" id="startX" name="startX" th:value="${startX}" required>
                         </div>
                         <div class="form-group">
-                            <label for="offsetY">Offset Y:</label>
-                            <input type="number" id="offsetY" name="y" th:value="${offsetY}" required>
+                            <label for="startY">Start Y:</label>
+                            <input type="number" id="startY" name="startY" th:value="${startY}" required>
                         </div>
-                        <button type="submit">Apply Offset</button>
+                        <div class="form-group">
+                            <label for="endX">End X:</label>
+                            <input type="number" id="endX" name="endX" th:value="${endX}" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="endY">End Y:</label>
+                            <input type="number" id="endY" name="endY" th:value="${endY}" required>
+                        </div>
+                        <button type="submit">Apply Points</button>
                     </form>
+
+                    <button type="button" id="setStartBtn" class="secondary active">Set Start Point</button>
+                    <button type="button" id="setEndBtn" class="secondary">Set End Point</button>
 
                     <div class="current-values">
                         <strong>Current Values:</strong><br>
-                        X: <span id="currentX" th:text="${offsetX}">0</span><br>
-                        Y: <span id="currentY" th:text="${offsetY}">0</span>
+                        Start: (<span id="currentStartX" th:text="${startX}">0</span>, <span id="currentStartY" th:text="${startY}">0</span>)<br>
+                        End: (<span id="currentEndX" th:text="${endX}">0</span>, <span id="currentEndY" th:text="${endY}">0</span>)
                     </div>
 
-                    <div id="status" class="status">Offset updated!</div>
+                    <div id="status" class="status">Points updated!</div>
                 </div>
 
                 <div class="image-container">
                     <h2>Live Preview</h2>
-                    <img id="liveImage" src="/Ariston/uncroppedimage" alt="Ariston Camera Feed">
-                    <p><small>Image refreshes automatically every 15 seconds</small></p>
+                    <div class="image-wrapper" id="imageWrapper">
+                        <img id="liveImage" src="/Ariston/uncroppedimage" alt="Ariston Camera Feed">
+                        <div id="startMarker" class="marker start" style="display:none;"></div>
+                        <div id="endMarker" class="marker end" style="display:none;"></div>
+                    </div>
+                    <p><small>Image refreshes automatically every 15 seconds. Click on image to set active point.</small></p>
                 </div>
             </div>
         </div>
@@ -243,26 +287,99 @@
     </div>
 
     <script>
-        document.getElementById('offsetForm').addEventListener('submit', function(e) {
+        let activePoint = 'start';
+
+        const startXInput = document.getElementById('startX');
+        const startYInput = document.getElementById('startY');
+        const endXInput = document.getElementById('endX');
+        const endYInput = document.getElementById('endY');
+        const setStartBtn = document.getElementById('setStartBtn');
+        const setEndBtn = document.getElementById('setEndBtn');
+        const liveImage = document.getElementById('liveImage');
+        const imageWrapper = document.getElementById('imageWrapper');
+        const startMarker = document.getElementById('startMarker');
+        const endMarker = document.getElementById('endMarker');
+
+        function updateMarkers() {
+            const sx = parseInt(startXInput.value);
+            const sy = parseInt(startYInput.value);
+            const ex = parseInt(endXInput.value);
+            const ey = parseInt(endYInput.value);
+
+            const rect = liveImage.getBoundingClientRect();
+            const imgWidth = liveImage.naturalWidth || rect.width;
+            const imgHeight = liveImage.naturalHeight || rect.height;
+            const scaleX = rect.width / imgWidth;
+            const scaleY = rect.height / imgHeight;
+
+            startMarker.style.left = (sx * scaleX) + 'px';
+            startMarker.style.top = (sy * scaleY) + 'px';
+            startMarker.style.display = 'block';
+
+            endMarker.style.left = (ex * scaleX) + 'px';
+            endMarker.style.top = (ey * scaleY) + 'px';
+            endMarker.style.display = 'block';
+        }
+
+        liveImage.addEventListener('load', updateMarkers);
+        if (liveImage.complete) updateMarkers();
+
+        setStartBtn.addEventListener('click', () => {
+            activePoint = 'start';
+            setStartBtn.classList.add('active');
+            setEndBtn.classList.remove('active');
+        });
+
+        setEndBtn.addEventListener('click', () => {
+            activePoint = 'end';
+            setEndBtn.classList.add('active');
+            setStartBtn.classList.remove('active');
+        });
+
+        imageWrapper.addEventListener('click', function(e) {
+            const rect = liveImage.getBoundingClientRect();
+            const imgWidth = liveImage.naturalWidth || rect.width;
+            const imgHeight = liveImage.naturalHeight || rect.height;
+            const scaleX = imgWidth / rect.width;
+            const scaleY = imgHeight / rect.height;
+
+            const x = Math.round((e.clientX - rect.left) * scaleX);
+            const y = Math.round((e.clientY - rect.top) * scaleY);
+
+            if (activePoint === 'start') {
+                startXInput.value = x;
+                startYInput.value = y;
+            } else {
+                endXInput.value = x;
+                endYInput.value = y;
+            }
+            updateMarkers();
+        });
+
+        document.getElementById('pointForm').addEventListener('submit', function(e) {
             e.preventDefault();
 
-            const x = document.getElementById('offsetX').value;
-            const y = document.getElementById('offsetY').value;
+            const startX = startXInput.value;
+            const startY = startYInput.value;
+            const endX = endXInput.value;
+            const endY = endYInput.value;
 
             fetch('/AristonManager/set', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
                 },
-                body: `x=${x}&y=${y}`
+                body: `startX=${startX}&startY=${startY}&endX=${endX}&endY=${endY}`
             })
             .then(response => response.json())
             .then(data => {
-                document.getElementById('currentX').textContent = data.offsetX;
-                document.getElementById('currentY').textContent = data.offsetY;
+                document.getElementById('currentStartX').textContent = data.startX;
+                document.getElementById('currentStartY').textContent = data.startY;
+                document.getElementById('currentEndX').textContent = data.endX;
+                document.getElementById('currentEndY').textContent = data.endY;
 
                 const status = document.getElementById('status');
-                status.textContent = 'Offset updated!';
+                status.textContent = 'Points updated!';
                 status.className = 'status success';
                 setTimeout(() => {
                     status.className = 'status';

--- a/src/test/java/com/keroleap/immerreader/Controller/AristonControllerTest.java
+++ b/src/test/java/com/keroleap/immerreader/Controller/AristonControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import com.keroleap.immerreader.AristonRest;
 import com.keroleap.immerreader.Service.AristonAnalyzerService;
 import com.keroleap.immerreader.SharedData.AristonData;
+import com.keroleap.immerreader.SharedData.AristonManagerData;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -26,6 +27,9 @@ class AristonControllerTest {
 
     @MockitoBean
     private AristonAnalyzerService aristonAnalyzerService;
+
+    @MockitoBean
+    private AristonManagerData aristonManagerData;
 
     @Test
     void getAristonRestData_returnsJson() throws Exception {

--- a/src/test/java/com/keroleap/immerreader/Controller/AristonManagerControllerTest.java
+++ b/src/test/java/com/keroleap/immerreader/Controller/AristonManagerControllerTest.java
@@ -32,65 +32,91 @@ class AristonManagerControllerTest {
     private ErrorStatistics errorStatistics;
 
     @Test
-    void getOffset_returnsCurrentValues() throws Exception {
-        when(aristonManagerData.getOffsetX()).thenReturn(5);
-        when(aristonManagerData.getOffsetY()).thenReturn(10);
+    void getPoints_returnsCurrentValues() throws Exception {
+        when(aristonManagerData.getStartX()).thenReturn(5);
+        when(aristonManagerData.getStartY()).thenReturn(10);
+        when(aristonManagerData.getEndX()).thenReturn(15);
+        when(aristonManagerData.getEndY()).thenReturn(20);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/AristonManager"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.offsetX").value(5))
-                .andExpect(jsonPath("$.offsetY").value(10));
+                .andExpect(jsonPath("$.startX").value(5))
+                .andExpect(jsonPath("$.startY").value(10))
+                .andExpect(jsonPath("$.endX").value(15))
+                .andExpect(jsonPath("$.endY").value(20));
     }
 
     @Test
-    void getOffset_defaultZeroValues() throws Exception {
-        when(aristonManagerData.getOffsetX()).thenReturn(0);
-        when(aristonManagerData.getOffsetY()).thenReturn(0);
+    void getPoints_defaultValues() throws Exception {
+        when(aristonManagerData.getStartX()).thenReturn(0);
+        when(aristonManagerData.getStartY()).thenReturn(0);
+        when(aristonManagerData.getEndX()).thenReturn(0);
+        when(aristonManagerData.getEndY()).thenReturn(0);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/AristonManager"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.offsetX").value(0))
-                .andExpect(jsonPath("$.offsetY").value(0));
+                .andExpect(jsonPath("$.startX").value(0))
+                .andExpect(jsonPath("$.startY").value(0))
+                .andExpect(jsonPath("$.endX").value(0))
+                .andExpect(jsonPath("$.endY").value(0));
     }
 
     @Test
-    void setOffset_updatesAndReturnsValues() throws Exception {
-        when(aristonManagerData.getOffsetX()).thenReturn(7);
-        when(aristonManagerData.getOffsetY()).thenReturn(3);
+    void setPoints_updatesAndReturnsValues() throws Exception {
+        when(aristonManagerData.getStartX()).thenReturn(7);
+        when(aristonManagerData.getStartY()).thenReturn(3);
+        when(aristonManagerData.getEndX()).thenReturn(14);
+        when(aristonManagerData.getEndY()).thenReturn(6);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/AristonManager/set")
-                        .param("x", "7")
-                        .param("y", "3"))
+                        .param("startX", "7")
+                        .param("startY", "3")
+                        .param("endX", "14")
+                        .param("endY", "6"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.offsetX").value(7))
-                .andExpect(jsonPath("$.offsetY").value(3));
+                .andExpect(jsonPath("$.startX").value(7))
+                .andExpect(jsonPath("$.startY").value(3))
+                .andExpect(jsonPath("$.endX").value(14))
+                .andExpect(jsonPath("$.endY").value(6));
 
-        verify(aristonManagerData).setOffsetX(7);
-        verify(aristonManagerData).setOffsetY(3);
+        verify(aristonManagerData).setStartX(7);
+        verify(aristonManagerData).setStartY(3);
+        verify(aristonManagerData).setEndX(14);
+        verify(aristonManagerData).setEndY(6);
     }
 
     @Test
-    void setOffset_negativeValues() throws Exception {
-        when(aristonManagerData.getOffsetX()).thenReturn(-5);
-        when(aristonManagerData.getOffsetY()).thenReturn(-10);
+    void setPoints_negativeValues() throws Exception {
+        when(aristonManagerData.getStartX()).thenReturn(-5);
+        when(aristonManagerData.getStartY()).thenReturn(-10);
+        when(aristonManagerData.getEndX()).thenReturn(-15);
+        when(aristonManagerData.getEndY()).thenReturn(-20);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/AristonManager/set")
-                        .param("x", "-5")
-                        .param("y", "-10"))
+                        .param("startX", "-5")
+                        .param("startY", "-10")
+                        .param("endX", "-15")
+                        .param("endY", "-20"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.offsetX").value(-5))
-                .andExpect(jsonPath("$.offsetY").value(-10));
+                .andExpect(jsonPath("$.startX").value(-5))
+                .andExpect(jsonPath("$.startY").value(-10))
+                .andExpect(jsonPath("$.endX").value(-15))
+                .andExpect(jsonPath("$.endY").value(-20));
 
-        verify(aristonManagerData).setOffsetX(-5);
-        verify(aristonManagerData).setOffsetY(-10);
+        verify(aristonManagerData).setStartX(-5);
+        verify(aristonManagerData).setStartY(-10);
+        verify(aristonManagerData).setEndX(-15);
+        verify(aristonManagerData).setEndY(-20);
     }
 
     @Test
-    void setOffset_missingParamReturnsBadRequest() throws Exception {
+    void setPoints_missingParamReturnsBadRequest() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.post("/AristonManager/set")
-                        .param("x", "5"))
+                        .param("startX", "5")
+                        .param("startY", "10")
+                        .param("endX", "15"))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/keroleap/immerreader/Service/AristonAnalyzerServiceTest.java
+++ b/src/test/java/com/keroleap/immerreader/Service/AristonAnalyzerServiceTest.java
@@ -11,34 +11,26 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class AristonAnalyzerServiceTest {
 
+    private static final int POINT_COUNT = 50;
+
     private AristonAnalyzerService service;
 
-    // The sampling coordinates in AristonAnalyzerService reach up to x=220, y=180.
-    // getLightValueAndDrawRedCross writes up to x+5=225, y+5=185, so the image must
-    // be at least 226 wide and 186 tall.
-    private static final int IMG_WIDTH = 300;
-    private static final int IMG_HEIGHT = 250;
+    // Use a large image so 50 interpolated points are well spaced and
+    // do not cause out-of-bounds when crosses are drawn.
+    private static final int IMG_WIDTH = 800;
+    private static final int IMG_HEIGHT = 800;
 
-    // x and y coordinate arrays mirrored from AristonAnalyzerService
-    private static final int[] PERCENT_X = {
-        160, 163, 166, 169, 172, 175, 178, 181, 184, 187,
-        190, 193, 196, 199, 202, 205, 208, 211, 214, 217, 220
-    };
-    private static final int[] PERCENT_Y = {
-        160, 161, 162, 163, 164, 165, 166, 167, 168, 169,
-        170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180
-    };
+    // Horizontal line with ~14 px spacing between points (700 px / 49 gaps)
+    private static final int START_X = 50;
+    private static final int START_Y = 400;
+    private static final int END_X = 750;
+    private static final int END_Y = 400;
 
     @BeforeEach
     void setUp() {
         service = new AristonAnalyzerService();
     }
 
-    /**
-     * Returns a BufferedImage filled with white pixels.
-     * White pixels (getRGB = 0xFFFFFFFF = -1) are above the LIGHT_THRESHOLD of
-     * -7000000, so getLightValueAndDrawRedCross returns false (no segment detected).
-     */
     private BufferedImage createWhiteImage() {
         BufferedImage img = new BufferedImage(IMG_WIDTH, IMG_HEIGHT, BufferedImage.TYPE_INT_RGB);
         int WHITE = 0xFFFFFF;
@@ -51,79 +43,92 @@ class AristonAnalyzerServiceTest {
     }
 
     /**
-     * Makes a small region around (cx, cy) black so that
-     * getLightValueAndDrawRedCross detects it (average RGB < -7000000).
+     * Blacken a generous filled square around (cx, cy) so that even after
+     * nearby 10-pixel-wide crosses are drawn by the analyzer there is still
+     * enough black left for detection.
      */
     private void setRegionBlack(BufferedImage img, int cx, int cy) {
-        int BLACK = 0x000000; // getRGB returns 0xFF000000 = -16777216
-        for (int dx = -5; dx <= 5; dx++) {
-            int px = cx + dx;
-            if (px >= 0 && px < img.getWidth()) {
-                img.setRGB(px, cy, BLACK);
-            }
-        }
-        for (int dy = -5; dy <= 5; dy++) {
-            int py = cy + dy;
-            if (py >= 0 && py < img.getHeight()) {
-                img.setRGB(cx, py, BLACK);
+        int BLACK = 0x000000; // getRGB returns -16777216
+        for (int dx = -7; dx <= 7; dx++) {
+            for (int dy = -7; dy <= 7; dy++) {
+                int px = cx + dx;
+                int py = cy + dy;
+                if (px >= 0 && px < img.getWidth() && py >= 0 && py < img.getHeight()) {
+                    img.setRGB(px, py, BLACK);
+                }
             }
         }
     }
 
+    private void setPointIndexBlack(BufferedImage img, int index) {
+        double t = (double) index / (POINT_COUNT - 1);
+        int x = (int) Math.round(START_X + (END_X - START_X) * t);
+        int y = (int) Math.round(START_Y + (END_Y - START_Y) * t);
+        setRegionBlack(img, x, y);
+    }
+
     @Test
     void getAristonRestData_allWhite_percentageIsZero() {
-        // No dark pixels → no point detected → percentage stays at 0
         BufferedImage img = createWhiteImage();
-        AristonRest result = service.getAristonRestData(img);
+        AristonRest result = service.getAristonRestData(img, START_X, START_Y, END_X, END_Y);
         assertEquals(0, result.getPercentage());
     }
 
     @Test
     void getAristonRestData_onlyFirstPointDark_percentage0() {
-        // Only index 0 dark → percentage = 0 * 5 = 0
         BufferedImage img = createWhiteImage();
-        setRegionBlack(img, PERCENT_X[0], PERCENT_Y[0]);
-        AristonRest result = service.getAristonRestData(img);
+        setPointIndexBlack(img, 0);
+        AristonRest result = service.getAristonRestData(img, START_X, START_Y, END_X, END_Y);
         assertEquals(0, result.getPercentage());
     }
 
     @Test
-    void getAristonRestData_firstTenPointsDark_percentage45() {
-        // Points 0–9 dark; points 10–20 white → last detected is index 9 → 9*5=45
-        BufferedImage img = createWhiteImage();
-        for (int i = 0; i <= 9; i++) {
-            setRegionBlack(img, PERCENT_X[i], PERCENT_Y[i]);
-        }
-        AristonRest result = service.getAristonRestData(img);
-        assertEquals(45, result.getPercentage());
-    }
-
-    @Test
     void getAristonRestData_onlyLastPointDark_percentage100() {
-        // Only the last index (20) dark → 20*5=100
         BufferedImage img = createWhiteImage();
-        setRegionBlack(img, PERCENT_X[20], PERCENT_Y[20]);
-        AristonRest result = service.getAristonRestData(img);
+        setPointIndexBlack(img, POINT_COUNT - 1);
+        AristonRest result = service.getAristonRestData(img, START_X, START_Y, END_X, END_Y);
         assertEquals(100, result.getPercentage());
     }
 
     @Test
     void getAristonRestData_allPointsDark_percentage100() {
-        // All points dark → last detected index is 20 → 100%
         BufferedImage img = createWhiteImage();
-        for (int i = 0; i < PERCENT_X.length; i++) {
-            setRegionBlack(img, PERCENT_X[i], PERCENT_Y[i]);
+        for (int i = 0; i < POINT_COUNT; i++) {
+            setPointIndexBlack(img, i);
         }
-        AristonRest result = service.getAristonRestData(img);
+        AristonRest result = service.getAristonRestData(img, START_X, START_Y, END_X, END_Y);
         assertEquals(100, result.getPercentage());
     }
 
     @Test
-    void getAristonRestData_halfwayPointDark_percentage50() {
-        // Only index 10 dark (all others white) → 10*5=50
+    void getAristonRestData_firstHalfDark_percentage49() {
         BufferedImage img = createWhiteImage();
-        setRegionBlack(img, PERCENT_X[10], PERCENT_Y[10]);
-        AristonRest result = service.getAristonRestData(img);
-        assertEquals(50, result.getPercentage());
+        int lastDarkIndex = (POINT_COUNT - 1) / 2; // 24
+        for (int i = 0; i <= lastDarkIndex; i++) {
+            setPointIndexBlack(img, i);
+        }
+        AristonRest result = service.getAristonRestData(img, START_X, START_Y, END_X, END_Y);
+        int expected = (int) Math.round(lastDarkIndex * 100.0 / (POINT_COUNT - 1));
+        assertEquals(expected, result.getPercentage());
+    }
+
+    @Test
+    void getAristonRestData_customLine_interpolatesCorrectly() {
+        BufferedImage img = createWhiteImage();
+        // Vertical line with ~12 px spacing (600 px / 49 gaps)
+        int startX = 400;
+        int startY = 50;
+        int endX = 400;
+        int endY = 650;
+
+        // Darken the point at index 25 (~midpoint)
+        double t = 25.0 / (POINT_COUNT - 1);
+        int expectedX = (int) Math.round(startX + (endX - startX) * t);
+        int expectedY = (int) Math.round(startY + (endY - startY) * t);
+        setRegionBlack(img, expectedX, expectedY);
+
+        AristonRest result = service.getAristonRestData(img, startX, startY, endX, endY);
+        int expectedPercentage = (int) Math.round(25 * 100.0 / (POINT_COUNT - 1));
+        assertEquals(expectedPercentage, result.getPercentage());
     }
 }

--- a/src/test/java/com/keroleap/immerreader/SharedData/AristonManagerDataTest.java
+++ b/src/test/java/com/keroleap/immerreader/SharedData/AristonManagerDataTest.java
@@ -9,7 +9,7 @@ class AristonManagerDataTest {
     /**
      * Directly instantiates AristonManagerData without a Spring context.
      * The @PostConstruct (load) is not invoked, but the AtomicInteger fields
-     * are initialised to 0 by their field declarations, so default-value
+     * are initialised to their declared defaults, so default-value
      * assertions are still meaningful.
      */
     private AristonManagerData newInstance() {
@@ -17,58 +17,86 @@ class AristonManagerDataTest {
     }
 
     @Test
-    void defaultOffsetXIsZero() {
-        assertEquals(0, newInstance().getOffsetX());
+    void defaultStartXIs160() {
+        assertEquals(160, newInstance().getStartX());
     }
 
     @Test
-    void defaultOffsetYIsZero() {
-        assertEquals(0, newInstance().getOffsetY());
+    void defaultStartYIs160() {
+        assertEquals(160, newInstance().getStartY());
     }
 
     @Test
-    void setAndGetOffsetX() {
+    void defaultEndXIs220() {
+        assertEquals(220, newInstance().getEndX());
+    }
+
+    @Test
+    void defaultEndYIs180() {
+        assertEquals(180, newInstance().getEndY());
+    }
+
+    @Test
+    void setAndGetStartX() {
         AristonManagerData data = newInstance();
-        data.setOffsetX(15);
-        assertEquals(15, data.getOffsetX());
+        data.setStartX(150);
+        assertEquals(150, data.getStartX());
     }
 
     @Test
-    void setAndGetOffsetY() {
+    void setAndGetStartY() {
         AristonManagerData data = newInstance();
-        data.setOffsetY(30);
-        assertEquals(30, data.getOffsetY());
+        data.setStartY(155);
+        assertEquals(155, data.getStartY());
     }
 
     @Test
-    void setOffsetXToNegative() {
+    void setAndGetEndX() {
         AristonManagerData data = newInstance();
-        data.setOffsetX(-5);
-        assertEquals(-5, data.getOffsetX());
+        data.setEndX(230);
+        assertEquals(230, data.getEndX());
     }
 
     @Test
-    void setOffsetYToNegative() {
+    void setAndGetEndY() {
         AristonManagerData data = newInstance();
-        data.setOffsetY(-10);
-        assertEquals(-10, data.getOffsetY());
+        data.setEndY(190);
+        assertEquals(190, data.getEndY());
     }
 
     @Test
-    void setOffsetXMultipleTimes() {
+    void setStartXToNegative() {
         AristonManagerData data = newInstance();
-        data.setOffsetX(10);
-        data.setOffsetX(20);
-        data.setOffsetX(5);
-        assertEquals(5, data.getOffsetX());
+        data.setStartX(-5);
+        assertEquals(-5, data.getStartX());
     }
 
     @Test
-    void xAndYAreIndependent() {
+    void setEndYToNegative() {
         AristonManagerData data = newInstance();
-        data.setOffsetX(7);
-        data.setOffsetY(13);
-        assertEquals(7, data.getOffsetX());
-        assertEquals(13, data.getOffsetY());
+        data.setEndY(-10);
+        assertEquals(-10, data.getEndY());
+    }
+
+    @Test
+    void setStartXMultipleTimes() {
+        AristonManagerData data = newInstance();
+        data.setStartX(10);
+        data.setStartX(20);
+        data.setStartX(5);
+        assertEquals(5, data.getStartX());
+    }
+
+    @Test
+    void coordinatesAreIndependent() {
+        AristonManagerData data = newInstance();
+        data.setStartX(7);
+        data.setStartY(13);
+        data.setEndX(25);
+        data.setEndY(30);
+        assertEquals(7, data.getStartX());
+        assertEquals(13, data.getStartY());
+        assertEquals(25, data.getEndX());
+        assertEquals(30, data.getEndY());
     }
 }


### PR DESCRIPTION
## Summary
Replaces the 21 hardcoded pixel detection points in the Ariston analyzer with 50 dynamically interpolated points along a user-configurable line between a start and end point.

## Changes
- **AristonManagerData**: Replaced `offsetX`/`offsetY` with `startX`/`startY`/`endX`/`endY`. Defaults are `160,160 → 220,180` (matching old first/last hardcoded points).
- **AristonAnalyzerService**: Removed hardcoded `PERCENT_X`/`PERCENT_Y` arrays. Now generates 50 interpolated points and calculates percentage as `round(lastDetectedIndex * 100 / 49)`.
- **AristonManagerController**: `/set` now accepts 4 point params; `/adjust` passes them to the template.
- **AristonController & AristonScheduler**: Wire `AristonManagerData` into analyzer calls.
- **ariston-manager.html**: Added image-click UI with toggle buttons for setting start/end points, plus green/red overlay markers.
- **Tests**: Updated for new APIs and interpolation behavior.

## Test Plan
- [x] `mvn clean test` passes (81 tests)
- [ ] Verify `/AristonManager/adjust` shows default points and image markers
- [ ] Click image to set start/end points
- [ ] Verify Power Level updates based on new line