### PR TITLE
Add error state to REST responses

### DIFF
--- a/src/main/java/com/keroleap/immerreader/AristonRest.java
+++ b/src/main/java/com/keroleap/immerreader/AristonRest.java
@@ -2,8 +2,24 @@ package com.keroleap.immerreader;
 
 public class AristonRest {
     private int percentage;
+    private boolean error;
+    private ErrorType errorType;
 
+    public boolean isError() {
+        return error;
+    }
 
+    public void setError(boolean error) {
+        this.error = error;
+    }
+
+    public ErrorType getErrorType() {
+        return errorType;
+    }
+
+    public void setErrorType(ErrorType errorType) {
+        this.errorType = errorType;
+    }
 
     public int getPercentage() {
         return percentage;

--- a/src/main/java/com/keroleap/immerreader/ErrorType.java
+++ b/src/main/java/com/keroleap/immerreader/ErrorType.java
@@ -1,0 +1,7 @@
+package com.keroleap.immerreader;
+
+public enum ErrorType {
+    TIMEOUT,
+    FETCH_ERROR,
+    UNKNOWN_DIGIT
+}

--- a/src/main/java/com/keroleap/immerreader/ImmerRest.java
+++ b/src/main/java/com/keroleap/immerreader/ImmerRest.java
@@ -5,6 +5,24 @@ public class ImmerRest {
     private int throttle;
     private boolean heating;
     private boolean boilerOn;
+    private boolean error;
+    private ErrorType errorType;
+
+    public boolean isError() {
+        return error;
+    }
+
+    public void setError(boolean error) {
+        this.error = error;
+    }
+
+    public ErrorType getErrorType() {
+        return errorType;
+    }
+
+    public void setErrorType(ErrorType errorType) {
+        this.errorType = errorType;
+    }
 
     public boolean isBoilerOn() {
         return boilerOn;

--- a/src/main/java/com/keroleap/immerreader/Scheduler/AristonScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/AristonScheduler.java
@@ -14,12 +14,15 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.keroleap.immerreader.AristonRest;
+import com.keroleap.immerreader.ErrorType;
 import com.keroleap.immerreader.Service.AristonAnalyzerService;
 import com.keroleap.immerreader.SharedData.AristonData;
 import com.keroleap.immerreader.SharedData.AristonManagerData;
 import com.keroleap.immerreader.SharedData.ErrorStatistics;
 
 import jakarta.annotation.PreDestroy;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
 public class AristonScheduler {
@@ -39,10 +42,14 @@ public class AristonScheduler {
     private ErrorStatistics errorStatistics;
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final AtomicInteger consecutiveErrors = new AtomicInteger(0);
+    private volatile ErrorType lastErrorType = null;
 
     @Scheduled(fixedRate = 15000)
     public void AristonScheduledRead() {
         if (!aristonManagerData.isEnabled()) {
+            consecutiveErrors.set(0);
+            lastErrorType = null;
             return;
         }
 
@@ -55,14 +62,32 @@ public class AristonScheduler {
 
         try {
             AristonRest result = future.get(10000, TimeUnit.MILLISECONDS);
+            result.setError(false);
+            result.setErrorType(null);
             aristonData.setAristonRest(result);
+            consecutiveErrors.set(0);
+            lastErrorType = null;
         } catch (TimeoutException e) {
             future.cancel(true);
             logger.warn("Timeout fetching Ariston data, keeping previous value.");
-            errorStatistics.recordError("Ariston", "timeout");
+            handleError(ErrorType.TIMEOUT);
         } catch (Exception e) {
             logger.error("Error fetching Ariston data: {}", e.getMessage());
-            errorStatistics.recordError("Ariston", "error");
+            handleError(ErrorType.FETCH_ERROR);
+        }
+    }
+
+    private void handleError(ErrorType errorType) {
+        errorStatistics.recordError("Ariston", errorType);
+        if (errorType.equals(lastErrorType)) {
+            consecutiveErrors.incrementAndGet();
+        } else {
+            lastErrorType = errorType;
+            consecutiveErrors.set(1);
+        }
+        if (consecutiveErrors.get() >= 5) {
+            aristonData.getAristonRest().setError(true);
+            aristonData.getAristonRest().setErrorType(errorType);
         }
     }
 

--- a/src/main/java/com/keroleap/immerreader/Scheduler/ImmerScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/ImmerScheduler.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.keroleap.immerreader.ErrorType;
 import com.keroleap.immerreader.ImmerRest;
 import com.keroleap.immerreader.Service.ImmerAnalyzerService;
 import com.keroleap.immerreader.SharedData.ImmerData;
@@ -44,6 +45,8 @@ public class ImmerScheduler {
 
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private final AtomicInteger currentDelayMs = new AtomicInteger(DEFAULT_DELAY_MS);
+    private final AtomicInteger consecutiveErrors = new AtomicInteger(0);
+    private volatile ErrorType lastErrorType = null;
 
     @PostConstruct
     public void init() {
@@ -57,6 +60,8 @@ public class ImmerScheduler {
     private void ImmerScheduledRead() {
         if (!immerManagerData.isEnabled()) {
             currentDelayMs.set(DEFAULT_DELAY_MS);
+            consecutiveErrors.set(0);
+            lastErrorType = null;
             scheduleNextRead();
             return;
         }
@@ -70,21 +75,23 @@ public class ImmerScheduler {
 
         try {
             ImmerRest result = future.get(1500, TimeUnit.MILLISECONDS);
+            result.setError(false);
+            result.setErrorType(null);
             immerData.setImmerRest(result);
             onReadSuccess();
         } catch (TimeoutException e) {
             future.cancel(true);
             logger.warn("Timeout fetching Immer data, keeping previous value.");
-            errorStatistics.recordError("Immer", "timeout");
-            onReadError();
+            handleError(ErrorType.TIMEOUT);
         } catch (Exception e) {
             logger.error("Error fetching Immer data: {}", e.getMessage());
-            errorStatistics.recordError("Immer", "error");
-            onReadError();
+            handleError(ErrorType.FETCH_ERROR);
         }
     }
 
     private void onReadSuccess() {
+        consecutiveErrors.set(0);
+        lastErrorType = null;
         currentDelayMs.set(DEFAULT_DELAY_MS);
         scheduleNextRead();
     }
@@ -94,6 +101,21 @@ public class ImmerScheduler {
         currentDelayMs.set(newDelay);
         logger.info("Increased delay to {} ms due to connection error", newDelay);
         scheduleNextRead();
+    }
+
+    private void handleError(ErrorType errorType) {
+        errorStatistics.recordError("Immer", errorType);
+        if (errorType.equals(lastErrorType)) {
+            consecutiveErrors.incrementAndGet();
+        } else {
+            lastErrorType = errorType;
+            consecutiveErrors.set(1);
+        }
+        if (consecutiveErrors.get() >= 5) {
+            immerData.getImmerRest().setError(true);
+            immerData.getImmerRest().setErrorType(errorType);
+        }
+        onReadError();
     }
 
     @PreDestroy

--- a/src/main/java/com/keroleap/immerreader/Service/ImmerAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/ImmerAnalyzerService.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.keroleap.immerreader.ErrorType;
 import com.keroleap.immerreader.ImmerRest;
 import com.keroleap.immerreader.SharedData.ErrorStatistics;
 
@@ -129,7 +130,7 @@ public class ImmerAnalyzerService {
         if (number == 1000) {
             logger.warn("Unknown digit detected: {}{}{}{}{}{}{}", digit1_1, digit1_2, digit1_3, digit1_4, digit1_5, digit1_6, digit1_7);
             if (errorStatistics != null) {
-                errorStatistics.recordError("Immer", "unknown_digit");
+                errorStatistics.recordError("Immer", ErrorType.UNKNOWN_DIGIT);
             }
         }
         return number;

--- a/src/main/java/com/keroleap/immerreader/SharedData/ErrorStatistics.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/ErrorStatistics.java
@@ -1,5 +1,6 @@
 package com.keroleap.immerreader.SharedData;
 
+import com.keroleap.immerreader.ErrorType;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
@@ -16,6 +17,12 @@ public class ErrorStatistics {
 
     public ErrorStatistics() {
         this.clock = Clock.systemDefaultZone();
+    }
+
+    public void recordError(String system, ErrorType errorType) {
+        String key = system + ":" + errorType.name();
+        errorCounts.computeIfAbsent(key, k -> new ErrorCounter()).increment();
+        cleanup();
     }
 
     public void recordError(String system, String errorType) {


### PR DESCRIPTION
## Summary
- Introduces `ErrorType` enum (`TIMEOUT`, `FETCH_ERROR`, `UNKNOWN_DIGIT`) to distinguish error categories
- Adds `error` (boolean) and `errorType` (ErrorType) fields to `ImmerRest` and `AristonRest`
- Both schedulers now track consecutive errors per type; after 5 consecutive failures of the same type, the existing shared data object is flagged with `error=true` and the corresponding `errorType`
- On successful reads, the error flag is cleared (`error=false`, `errorType=null`)
- `ErrorStatistics` updated with an overloaded `recordError(String, ErrorType)` method
- `ImmerAnalyzerService` updated to use `ErrorType.UNKNOWN_DIGIT` instead of raw string

## Test plan
- [x] `mvn test` passes
- [x] `mvn clean compile` succeeds
- [ ] Verify `/Immer/immerrestdata` and `/Ariston/aristonrestdata` return `error`/`errorType` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)