### PR TITLE
Speed up CI builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,8 +19,24 @@ env:
 
 
 jobs:
-  build:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run tests
+        run: mvn test -T 1C
+
+  build:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -31,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer

--- a/.github/workflows/pmd.yml
+++ b/.github/workflows/pmd.yml
@@ -22,12 +22,13 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 25
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '25'
           distribution: 'temurin'
+          cache: 'maven'
       - name: Run PMD
         id: pmd
         uses: pmd/pmd-github-action@v2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y maven
 COPY pom.xml .
 RUN mvn dependency:go-offline
 COPY src ./src
-RUN mvn package
+RUN mvn package -DskipTests
 
 FROM eclipse-temurin:25-jre-alpine
 RUN mkdir -p /data


### PR DESCRIPTION
## Summary
- **Dockerfile**: `mvn package -DskipTests` to avoid running tests inside the Docker build (especially slow under QEMU for arm64)
- **docker-publish.yml**: split into `test` + `build` jobs
  - `test` job runs `mvn test -T 1C` with Maven dependency caching
  - `build` job depends on `test`, so Docker build only starts after tests pass
  - Updated all actions to latest versions (checkout@v4, setup-java@v4, etc.)
- **pmd.yml**: added `cache: 'maven'` to `setup-java@v4` for faster PMD runs

## Test plan
- [x] `mvn clean package -DskipTests` builds successfully locally
- [ ] Verify GHA test job passes on this PR
- [ ] Verify Docker build job starts only after test job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)