### PR TITLE
Add Ebedlo RTSP camera support with polygon-based HSV light detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,31 +3,37 @@
 ## Build & Run
 
 ```bash
-mvn clean package           # Build
-mvn test                    # All tests
-mvn test -Dtest=ClassName   # Single test class
-mvn spring-boot:run         # Run app
+mvn clean package                # Build
+mvn test                         # All tests
+mvn test -Dtest=ClassName        # Single test class
+mvn spring-boot:run              # Run app
 mvn versions:display-dependency-updates  # Check updates
 ```
 
-**Java version:** Java 25 throughout (pom.xml, CI workflows, Docker)
+**Java version:** 25 (pom.xml, CI, Docker)
 
 ## Architecture
 
-Spring Boot 3.4.5 app (`@EnableScheduling`) for boiler display image processing.
+Spring Boot 3.4.5 (`@EnableScheduling`) for IP-camera boiler display image processing.
 
 ### Dual System
 
-| System   | Prefix       | Interval | Data                    |
-|----------|--------------|----------|-------------------------|
-| Immergas | `Immer*`     | 2 sec    | Temp, throttle, status  |
-| Ariston  | `Ariston*`   | 15 sec   | Percentage (0-100%)     |
+| System   | Prefix       | Intervals / Mechanism                    | Data                       |
+|----------|--------------|------------------------------------------|----------------------------|
+| Immergas | `Immer*`     | Manual scheduler, 2 s + backoff on error | Temp, throttle, status     |
+| Ariston  | `Ariston*`   | `@Scheduled(fixedRate=15000)`            | Percentage (0–100%)        |
 
 ### Flow
 
 ```
-IP Camera → ImageProcessingService → Scheduler → SharedData (singleton) → REST Controller
+IP Camera (hardcoded URL) → Scheduler → AnalyzerService → SharedData (singletons) → Controller
 ```
+
+- **Schedulers** call `AnalyzerService` directly; there is no separate `ImageProcessingService`.
+- **ImmerScheduler** uses its own `ScheduledExecutorService`. On success the next read is after 2 s; on timeout/error it increments the delay by 1 s up to 60 s.
+- **AristonScheduler** uses Spring's `@Scheduled(fixedRate = 15000)` and executor-based timeout.
+- **AnalyzerServices** mutate the input `BufferedImage` in place (draw red/white crosses) before analysis.
+- Camera URLs are **hardcoded** in scheduler and controller classes, not in `application.properties`.
 
 ### Package Structure
 
@@ -36,17 +42,23 @@ IP Camera → ImageProcessingService → Scheduler → SharedData (singleton) �
 - `Scheduler/` - Polling (`ImmerScheduler`, `AristonScheduler`)
 - `SharedData/` - Thread-safe state containers
 
+## Data Persistence
+
+- `ImmerManagerData` → `/data/offset.properties` (offsetX, offsetY, enabled)
+- `AristonManagerData` → `/data/ariston.properties` (startX/startY, endX/endY, enabled)
+- Both are `@Component` singletons that load on `@PostConstruct` and write on every setter call.
+
 ## CI/CD
 
-- **CodeQL:** Java/Kotlin analysis on push/PR to `main`
-- **PMD:** `rulesets/java/quickstart.xml`, fails on violations
-- **Docker:** Multi-platform (amd64/arm64), pushes to `kerozoli/immerreader:latest`
+- **CodeQL:** Repository uses GitHub's default setup (custom workflow removed). Do not re-add a manual workflow.
+- **PMD:** `rulesets/java/quickstart.xml`, fails the build on violations.
+- **Docker:** Multi-platform (`linux/amd64,linux/arm64`), pushes `kerozoli/immerreader:latest`.
 
 ## Configuration
 
 `src/main/resources/application.properties`:
 - `server.port=8099`
-- Camera URLs are hardcoded in scheduler/service classes
+- Camera URLs are **not** here; they are hardcoded in scheduler/service/controller classes.
 
 ## Docker
 
@@ -54,3 +66,5 @@ IP Camera → ImageProcessingService → Scheduler → SharedData (singleton) �
 docker build -t kerozoli/immerreader .
 docker run -p 8099:8099 -v /data:/data kerozoli/immerreader
 ```
+
+- Data persistence requires `-v /data:/data`; properties and error stats rely on it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mvn dependency:go-offline
 COPY src ./src
 RUN mvn package -DskipTests
 
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25-jre
 RUN mkdir -p /data
 VOLUME /data
 COPY --from=builder /app/target/immerreader-1.0.0.jar immerreader-1.0.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,16 @@
 			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.bytedeco</groupId>
+			<artifactId>javacv</artifactId>
+			<version>1.5.11</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bytedeco</groupId>
+			<artifactId>ffmpeg-platform</artifactId>
+			<version>7.1-1.5.11</version>
+		</dependency>
  </dependencies>
 
 	<build>

--- a/src/main/java/com/keroleap/immerreader/Controller/EbedloController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/EbedloController.java
@@ -1,0 +1,90 @@
+package com.keroleap.immerreader.Controller;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.keroleap.immerreader.EbedloRest;
+import com.keroleap.immerreader.Service.EbedloAnalyzerService;
+import com.keroleap.immerreader.SharedData.EbedloData;
+import com.keroleap.immerreader.SharedData.EbedloManagerData;
+
+@Controller
+@RequestMapping("/Ebedlo")
+public class EbedloController {
+
+    @Value("${camera.ebedlo.url}")
+    private String cameraUrl;
+
+    @Autowired
+    private EbedloData ebedloData;
+
+    @Autowired
+    private EbedloAnalyzerService ebedloAnalyzerService;
+
+    @Autowired
+    private EbedloManagerData ebedloManagerData;
+
+    @GetMapping(value = "/image", produces = MediaType.IMAGE_JPEG_VALUE)
+    public @ResponseBody byte[] getImage() throws IOException {
+        return writeJpeg(analyzeAndReturnImage());
+    }
+
+    @GetMapping(value = "/uncroppedimage", produces = MediaType.IMAGE_JPEG_VALUE)
+    public @ResponseBody byte[] getUncroppedImage() throws IOException {
+        return writeJpeg(analyzeAndReturnImage());
+    }
+
+    private BufferedImage analyzeAndReturnImage() {
+        BufferedImage cachedImage = ebedloAnalyzerService.getBufferedImage(cameraUrl);
+        ebedloAnalyzerService.getEbedloRestData(cachedImage, ebedloManagerData);
+        return cachedImage;
+    }
+
+    private byte[] writeJpeg(BufferedImage image) throws IOException {
+        if (image == null) {
+            image = createPlaceholderImage();
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(image, "jpg", baos);
+        return baos.toByteArray();
+    }
+
+    private BufferedImage createPlaceholderImage() {
+        BufferedImage placeholder = new BufferedImage(320, 240, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = placeholder.createGraphics();
+        g.setColor(Color.BLACK);
+        g.fillRect(0, 0, 320, 240);
+        g.setColor(Color.WHITE);
+        g.drawString("No camera image available", 20, 120);
+        g.dispose();
+        return placeholder;
+    }
+
+    @RequestMapping(value = "/ebedlodata")
+    public ModelAndView getEbedloData() throws IOException {
+        BufferedImage cachedImage = ebedloAnalyzerService.getBufferedImage(cameraUrl);
+        ModelAndView modelAndView = new ModelAndView("ebedlodata");
+        modelAndView.addObject("message", ebedloAnalyzerService.getEbedloRestData(cachedImage, ebedloManagerData).toString());
+        return modelAndView;
+    }
+
+    @RequestMapping(value = "/ebedlorestdata")
+    @ResponseBody
+    public EbedloRest getEbedloRestData() {
+        return ebedloData.getEbedloRest();
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/Controller/EbedloManagerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/EbedloManagerController.java
@@ -1,7 +1,6 @@
 package com.keroleap.immerreader.Controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/keroleap/immerreader/Controller/EbedloManagerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/EbedloManagerController.java
@@ -1,0 +1,79 @@
+package com.keroleap.immerreader.Controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.keroleap.immerreader.SharedData.EbedloData;
+import com.keroleap.immerreader.SharedData.EbedloManagerData;
+import com.keroleap.immerreader.SharedData.ErrorStatistics;
+
+@Controller
+@RequestMapping("/EbedloManager")
+public class EbedloManagerController {
+
+    private static final int POINT_COUNT = 10;
+
+    @Autowired
+    private EbedloManagerData ebedloManagerData;
+
+    @Autowired
+    private EbedloData ebedloData;
+
+    @Autowired
+    private ErrorStatistics errorStatistics;
+
+    @PostMapping("/set")
+    @ResponseBody
+    public ResponseEntity<?> setPoints(@RequestParam String points, @RequestParam int threshold) {
+        String[] parts = points.split(",");
+        if (parts.length != POINT_COUNT * 2) {
+            return ResponseEntity.badRequest().body("Expected " + (POINT_COUNT * 2) + " comma-separated coordinates, got " + parts.length);
+        }
+        try {
+            int[] xs = new int[POINT_COUNT];
+            int[] ys = new int[POINT_COUNT];
+            for (int i = 0; i < POINT_COUNT; i++) {
+                xs[i] = Integer.parseInt(parts[i * 2].trim());
+                ys[i] = Integer.parseInt(parts[i * 2 + 1].trim());
+            }
+            ebedloManagerData.setPoints(xs, ys);
+            ebedloManagerData.setThreshold(threshold);
+            return ResponseEntity.ok(ebedloManagerData);
+        } catch (NumberFormatException e) {
+            return ResponseEntity.badRequest().body("Invalid coordinate value: " + e.getMessage());
+        }
+    }
+
+    @PostMapping("/toggle")
+    @ResponseBody
+    public EbedloManagerData toggleEnabled() {
+        ebedloManagerData.setEnabled(!ebedloManagerData.isEnabled());
+        return ebedloManagerData;
+    }
+
+    @GetMapping
+    @ResponseBody
+    public EbedloManagerData getPoints() {
+        return ebedloManagerData;
+    }
+
+    @GetMapping("/adjust")
+    public ModelAndView adjustPoints() {
+        ModelAndView modelAndView = new ModelAndView("ebedlo-manager");
+        modelAndView.addObject("xs", ebedloManagerData.getXs());
+        modelAndView.addObject("ys", ebedloManagerData.getYs());
+        modelAndView.addObject("threshold", ebedloManagerData.getThreshold());
+        modelAndView.addObject("enabled", ebedloManagerData.isEnabled());
+        modelAndView.addObject("ebedloRest", ebedloData.getEbedloRest());
+        modelAndView.addObject("errorStats", errorStatistics.getLastErrorCounts("Ebedlo"));
+        return modelAndView;
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/Controller/HomeController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/HomeController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.ModelAndView;
 
 import com.keroleap.immerreader.SharedData.AristonManagerData;
+import com.keroleap.immerreader.SharedData.EbedloManagerData;
 import com.keroleap.immerreader.SharedData.ImmerManagerData;
 
 @Controller
@@ -17,11 +18,15 @@ public class HomeController {
     @Autowired
     private AristonManagerData aristonManagerData;
 
+    @Autowired
+    private EbedloManagerData ebedloManagerData;
+
     @GetMapping("/")
     public ModelAndView home() {
         ModelAndView modelAndView = new ModelAndView("index");
         modelAndView.addObject("immerEnabled", immerManagerData.isEnabled());
         modelAndView.addObject("aristonEnabled", aristonManagerData.isEnabled());
+        modelAndView.addObject("ebedloEnabled", ebedloManagerData.isEnabled());
         return modelAndView;
     }
 }

--- a/src/main/java/com/keroleap/immerreader/EbedloRest.java
+++ b/src/main/java/com/keroleap/immerreader/EbedloRest.java
@@ -1,0 +1,45 @@
+package com.keroleap.immerreader;
+
+public class EbedloRest {
+    private boolean on;
+    private long averageValue;
+    private boolean error;
+    private ErrorType errorType;
+
+    public long getAverageValue() {
+        return averageValue;
+    }
+
+    public void setAverageValue(long averageValue) {
+        this.averageValue = averageValue;
+    }
+
+    public boolean isOn() {
+        return on;
+    }
+
+    public void setOn(boolean on) {
+        this.on = on;
+    }
+
+    public boolean isError() {
+        return error;
+    }
+
+    public void setError(boolean error) {
+        this.error = error;
+    }
+
+    public ErrorType getErrorType() {
+        return errorType;
+    }
+
+    public void setErrorType(ErrorType errorType) {
+        this.errorType = errorType;
+    }
+
+    @Override
+    public String toString() {
+        return "Ebedlo [on=" + on + ", error=" + error + "]";
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/Scheduler/EbedloScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/EbedloScheduler.java
@@ -1,0 +1,110 @@
+package com.keroleap.immerreader.Scheduler;
+
+import java.awt.image.BufferedImage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.keroleap.immerreader.EbedloRest;
+import com.keroleap.immerreader.ErrorType;
+import com.keroleap.immerreader.Service.EbedloAnalyzerService;
+import com.keroleap.immerreader.SharedData.EbedloData;
+import com.keroleap.immerreader.SharedData.EbedloManagerData;
+import com.keroleap.immerreader.SharedData.ErrorStatistics;
+
+import jakarta.annotation.PreDestroy;
+
+@Component
+public class EbedloScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(EbedloScheduler.class);
+
+    @Value("${camera.ebedlo.url}")
+    private String cameraUrl;
+
+    @Autowired
+    private EbedloData ebedloData;
+
+    @Autowired
+    private EbedloAnalyzerService ebedloAnalyzerService;
+
+    @Autowired
+    private EbedloManagerData ebedloManagerData;
+
+    @Autowired
+    private ErrorStatistics errorStatistics;
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final AtomicInteger consecutiveErrors = new AtomicInteger(0);
+    private volatile ErrorType lastErrorType = null;
+
+    @Scheduled(fixedRate = 10000)
+    public void EbedloScheduledRead() {
+        if (!ebedloManagerData.isEnabled()) {
+            consecutiveErrors.set(0);
+            lastErrorType = null;
+            return;
+        }
+
+        Future<EbedloRest> future = executor.submit(() -> {
+            BufferedImage cachedImage = ebedloAnalyzerService.getBufferedImage(cameraUrl);
+            return ebedloAnalyzerService.getEbedloRestData(cachedImage, ebedloManagerData);
+        });
+
+        try {
+            EbedloRest result = future.get(5000, TimeUnit.MILLISECONDS);
+            result.setError(false);
+            result.setErrorType(null);
+
+            ebedloData.addOnDecision(result.isOn());
+            boolean smoothedOn = ebedloData.getSmoothedOn();
+
+            EbedloRest stored = new EbedloRest();
+            stored.setOn(smoothedOn);
+            stored.setAverageValue(result.getAverageValue());
+            stored.setError(false);
+            stored.setErrorType(null);
+            ebedloData.setEbedloRest(stored);
+
+            consecutiveErrors.set(0);
+            lastErrorType = null;
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            logger.warn("Timeout fetching Ebedlo data, keeping previous value.");
+            handleError(ErrorType.TIMEOUT);
+        } catch (Exception e) {
+            logger.error("Error fetching Ebedlo data: {}", e.getMessage());
+            handleError(ErrorType.FETCH_ERROR);
+        }
+    }
+
+    private void handleError(ErrorType errorType) {
+        errorStatistics.recordError("Ebedlo", errorType);
+        if (errorType.equals(lastErrorType)) {
+            consecutiveErrors.incrementAndGet();
+        } else {
+            lastErrorType = errorType;
+            consecutiveErrors.set(1);
+        }
+        if (consecutiveErrors.get() >= 5) {
+            ebedloData.getEbedloRest().setError(true);
+            ebedloData.getEbedloRest().setErrorType(errorType);
+        }
+    }
+
+    @PreDestroy
+    public void destroy() {
+        logger.info("Shutting down EbedloScheduler executor.");
+        executor.shutdownNow();
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/Service/AristonAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/AristonAnalyzerService.java
@@ -1,17 +1,10 @@
 package com.keroleap.immerreader.Service;
 
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URL;
-
-import javax.imageio.ImageIO;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.keroleap.immerreader.AristonRest;
@@ -22,6 +15,9 @@ public class AristonAnalyzerService {
     private static final Logger logger = LoggerFactory.getLogger(AristonAnalyzerService.class);
     private static final int LIGHT_THRESHOLD = -7000000;
     private static final int POINT_COUNT = 50;
+
+    @Autowired
+    private CameraImageService cameraImageService;
 
     public AristonRest getAristonRestData(BufferedImage bufferedImage,
                                           int startX, int startY,
@@ -53,24 +49,8 @@ public class AristonAnalyzerService {
         return aristonRest;
     }
 
-    public BufferedImage getBufferedImage(String imageUrl) throws IOException {
-        try {
-            URL url = URI.create(imageUrl).toURL();
-            try (InputStream stream = url.openStream();
-                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-                byte[] chunk = new byte[4096];
-                int bytesRead;
-                while ((bytesRead = stream.read(chunk)) > 0) {
-                    outputStream.write(chunk, 0, bytesRead);
-                }
-                try (ByteArrayInputStream input = new ByteArrayInputStream(outputStream.toByteArray())) {
-                    return ImageIO.read(input);
-                }
-            }
-        } catch (IOException e) {
-            logger.error("Error fetching image from {}: {}", imageUrl, e.getMessage());
-            return null;
-        }
+    public BufferedImage getBufferedImage(String imageUrl) {
+        return cameraImageService.capture(imageUrl);
     }
 
     private boolean detectLightValue(int x, int y, BufferedImage image) {

--- a/src/main/java/com/keroleap/immerreader/Service/CameraImageService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/CameraImageService.java
@@ -1,0 +1,58 @@
+package com.keroleap.immerreader.Service;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+
+import javax.imageio.ImageIO;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CameraImageService {
+
+    private static final Logger logger = LoggerFactory.getLogger(CameraImageService.class);
+
+    @Autowired
+    private RtspFrameGrabber rtspFrameGrabber;
+
+    public BufferedImage capture(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            logger.warn("Camera URL is null or blank");
+            return null;
+        }
+
+        try {
+            if (imageUrl.startsWith("rtsp://")) {
+                return rtspFrameGrabber.getLatestFrame(imageUrl);
+            }
+            return captureHttp(imageUrl);
+        } catch (Exception e) {
+            logger.error("Error fetching image from {}: {}", imageUrl, e.getMessage());
+            return null;
+        }
+    }
+
+    private BufferedImage captureHttp(String imageUrl) throws IOException {
+        URL url = URI.create(imageUrl).toURL();
+        try (InputStream stream = url.openStream();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            byte[] chunk = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = stream.read(chunk)) > 0) {
+                outputStream.write(chunk, 0, bytesRead);
+            }
+
+            try (ByteArrayInputStream input = new ByteArrayInputStream(outputStream.toByteArray())) {
+                return ImageIO.read(input);
+            }
+        }
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/Service/EbedloAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/EbedloAnalyzerService.java
@@ -1,0 +1,197 @@
+package com.keroleap.immerreader.Service;
+
+import java.awt.Polygon;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.keroleap.immerreader.EbedloRest;
+import com.keroleap.immerreader.SharedData.EbedloManagerData;
+
+@Service
+public class EbedloAnalyzerService {
+
+    private static final Logger logger = LoggerFactory.getLogger(EbedloAnalyzerService.class);
+    private static final double TRIM_PERCENTAGE = 0.10;
+
+    @Autowired
+    private CameraImageService cameraImageService;
+
+    public BufferedImage getBufferedImage(String imageUrl) {
+        return cameraImageService.capture(imageUrl);
+    }
+
+    public EbedloRest getEbedloRestData(BufferedImage bufferedImage, EbedloManagerData managerData) {
+        EbedloRest ebedloRest = new EbedloRest();
+        if (bufferedImage == null) {
+            logger.warn("No image available for Ebedlo analysis");
+            ebedloRest.setOn(false);
+            return ebedloRest;
+        }
+
+        int count = managerData.getPointCount();
+        int[] xs = new int[count];
+        int[] ys = new int[count];
+        int configuredPoints = 0;
+        for (int i = 0; i < count; i++) {
+            int x = managerData.getX(i);
+            int y = managerData.getY(i);
+            xs[i] = x;
+            ys[i] = y;
+            if (x != 0 || y != 0) {
+                configuredPoints++;
+            }
+        }
+
+        if (configuredPoints == 0) {
+            logger.debug("No Ebedlo points configured yet, defaulting to OFF");
+            ebedloRest.setOn(false);
+            return ebedloRest;
+        }
+
+        if (configuredPoints < 3) {
+            logger.warn("Only {} Ebedlo points configured, need at least 3 to form an area", configuredPoints);
+            ebedloRest.setOn(false);
+            return ebedloRest;
+        }
+
+        Polygon area = new Polygon(xs, ys, count);
+        double averageValue = computeTrimmedMeanValueInPolygon(bufferedImage, area);
+        boolean on = averageValue > managerData.getThreshold();
+
+        ebedloRest.setOn(on);
+        ebedloRest.setAverageValue(Math.round(averageValue));
+        drawPolygonMarkers(bufferedImage, xs, ys, count);
+        return ebedloRest;
+    }
+
+    private double computeTrimmedMeanValueInPolygon(BufferedImage image, Polygon polygon) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+        List<Integer> values = new ArrayList<>();
+
+        int minX = Math.max(0, polygon.getBounds().x);
+        int minY = Math.max(0, polygon.getBounds().y);
+        int maxX = Math.min(width, minX + polygon.getBounds().width);
+        int maxY = Math.min(height, minY + polygon.getBounds().height);
+
+        for (int y = minY; y < maxY; y++) {
+            for (int x = minX; x < maxX; x++) {
+                if (polygon.contains(x, y)) {
+                    int rgb = image.getRGB(x, y);
+                    int r = (rgb >> 16) & 0xFF;
+                    int g = (rgb >> 8) & 0xFF;
+                    int b = rgb & 0xFF;
+                    float[] hsv = rgbToHsv(r, g, b);
+                    values.add(Math.round(hsv[2] * 255));
+                }
+            }
+        }
+
+        if (values.isEmpty()) {
+            return 0;
+        }
+
+        Collections.sort(values);
+        int trimCount = (int) Math.floor(values.size() * TRIM_PERCENTAGE);
+        int start = trimCount;
+        int end = values.size() - trimCount;
+        if (end <= start) {
+            start = 0;
+            end = values.size();
+        }
+
+        long total = 0;
+        for (int i = start; i < end; i++) {
+            total += values.get(i);
+        }
+        return (double) total / (end - start);
+    }
+
+    private void drawPolygonMarkers(BufferedImage image, int[] xs, int[] ys, int count) {
+        for (int i = 0; i < count; i++) {
+            if (xs[i] == 0 && ys[i] == 0) {
+                continue;
+            }
+            int next = (i + 1) % count;
+            while ((xs[next] == 0 && ys[next] == 0) && next != i) {
+                next = (next + 1) % count;
+            }
+            if (next != i) {
+                drawLine(image, xs[i], ys[i], xs[next], ys[next], 16777215);
+            }
+            drawCross(image, xs[i], ys[i], i == 0 ? 16711680 : 65280);
+        }
+    }
+
+    private void drawLine(BufferedImage image, int x1, int y1, int x2, int y2, int color) {
+        int dx = Math.abs(x2 - x1);
+        int dy = Math.abs(y2 - y1);
+        int sx = x1 < x2 ? 1 : -1;
+        int sy = y1 < y2 ? 1 : -1;
+        int err = dx - dy;
+
+        int width = image.getWidth();
+        int height = image.getHeight();
+
+        while (true) {
+            if (x1 >= 0 && x1 < width && y1 >= 0 && y1 < height) {
+                image.setRGB(x1, y1, color);
+            }
+            if (x1 == x2 && y1 == y2) {
+                break;
+            }
+            int e2 = 2 * err;
+            if (e2 > -dy) {
+                err -= dy;
+                x1 += sx;
+            }
+            if (e2 < dx) {
+                err += dx;
+                y1 += sy;
+            }
+        }
+    }
+
+    private void drawCross(BufferedImage image, int x, int y, int color) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+        for (int a = x - 5; a < x + 5; a++) {
+            if (a >= 0 && a < width) {
+                image.setRGB(a, y, color);
+            }
+        }
+        for (int b = y - 5; b < y + 5; b++) {
+            if (b >= 0 && b < height) {
+                image.setRGB(x, b, color);
+            }
+        }
+    }
+
+    private float[] rgbToHsv(int r, int g, int b) {
+        float rf = r / 255.0f;
+        float gf = g / 255.0f;
+        float bf = b / 255.0f;
+        float max = Math.max(rf, Math.max(gf, bf));
+        float min = Math.min(rf, Math.min(gf, bf));
+        float v = max;
+        float s = max == 0 ? 0 : (max - min) / max;
+        float h;
+        if (max == min) {
+            h = 0;
+        } else if (max == rf) {
+            h = (60 * ((gf - bf) / (max - min)) + 360) % 360;
+        } else if (max == gf) {
+            h = (60 * ((bf - rf) / (max - min)) + 120);
+        } else {
+            h = (60 * ((rf - gf) / (max - min)) + 240);
+        }
+        return new float[] { h, s, v };
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/Service/EbedloAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/EbedloAnalyzerService.java
@@ -120,7 +120,7 @@ public class EbedloAnalyzerService {
                 continue;
             }
             int next = (i + 1) % count;
-            while ((xs[next] == 0 && ys[next] == 0) && next != i) {
+            while (xs[next] == 0 && ys[next] == 0 && next != i) {
                 next = (next + 1) % count;
             }
             if (next != i) {

--- a/src/main/java/com/keroleap/immerreader/Service/ImmerAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/ImmerAnalyzerService.java
@@ -1,15 +1,7 @@
 package com.keroleap.immerreader.Service;
 
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URL;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.imageio.ImageIO;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +21,9 @@ public class ImmerAnalyzerService {
 
     @Autowired(required = false)
     private ErrorStatistics errorStatistics;
+
+    @Autowired
+    private CameraImageService cameraImageService;
 
     public ImmerRest getImmerRestData(BufferedImage bufferedImage, int offsetX, int offsetY) {
         boolean heating = getLightValueAnnDrawRedCross(495 + offsetX, 215 + offsetY, bufferedImage);
@@ -136,25 +131,8 @@ public class ImmerAnalyzerService {
         return number;
     }
 
-    public BufferedImage getBufferedImage(String imageUrl) throws IOException {
-        try {
-            URL url = URI.create(imageUrl).toURL();
-            try (InputStream stream = url.openStream();
-                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-                byte[] chunk = new byte[4096];
-                int bytesRead;
-                while ((bytesRead = stream.read(chunk)) > 0) {
-                    outputStream.write(chunk, 0, bytesRead);
-                }
-
-                try (ByteArrayInputStream input = new ByteArrayInputStream(outputStream.toByteArray())) {
-                    return ImageIO.read(input);
-                }
-            }
-        } catch (IOException e) {
-            logger.error("Error fetching image from {}: {}", imageUrl, e.getMessage());
-            return null;
-        }
+    public BufferedImage getBufferedImage(String imageUrl) {
+        return cameraImageService.capture(imageUrl);
     }
 
     private boolean getLightValueAnnDrawRedCross(int x, int y, BufferedImage image) {

--- a/src/main/java/com/keroleap/immerreader/Service/RtspFrameGrabber.java
+++ b/src/main/java/com/keroleap/immerreader/Service/RtspFrameGrabber.java
@@ -1,0 +1,156 @@
+package com.keroleap.immerreader.Service;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+import org.bytedeco.javacv.Frame;
+import org.bytedeco.javacv.Java2DFrameConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PreDestroy;
+
+@Service
+public class RtspFrameGrabber {
+
+    private static final Logger logger = LoggerFactory.getLogger(RtspFrameGrabber.class);
+    private static final long FRAME_TIMEOUT_MS = 10000;
+    private static final long GRABBER_ERROR_DELAY_MS = 2000;
+
+    private final Map<String, StreamHolder> holders = new ConcurrentHashMap<>();
+    private final AtomicBoolean shutdown = new AtomicBoolean(false);
+
+    public BufferedImage getLatestFrame(String rtspUrl) {
+        StreamHolder holder = holders.computeIfAbsent(rtspUrl, StreamHolder::new);
+        return holder.getFrame();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        shutdown.set(true);
+        holders.values().forEach(StreamHolder::stop);
+    }
+
+    private class StreamHolder {
+        private final String rtspUrl;
+        private final ReentrantLock lock = new ReentrantLock();
+        private final AtomicLong lastFrameTime = new AtomicLong(0);
+        private volatile BufferedImage latestFrame;
+        private volatile Thread workerThread;
+
+        StreamHolder(String rtspUrl) {
+            this.rtspUrl = rtspUrl;
+            startWorker();
+        }
+
+        void startWorker() {
+            lock.lock();
+            try {
+                if (workerThread != null && workerThread.isAlive()) {
+                    return;
+                }
+                Thread thread = new Thread(this::runGrabber, "rtsp-grabber-" + rtspUrl.replaceAll("[^a-zA-Z0-9]", "_"));
+                thread.setDaemon(true);
+                workerThread = thread;
+                thread.start();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        BufferedImage getFrame() {
+            long start = System.currentTimeMillis();
+            while (System.currentTimeMillis() - start < FRAME_TIMEOUT_MS) {
+                BufferedImage frame = latestFrame;
+                if (frame != null && System.currentTimeMillis() - lastFrameTime.get() < FRAME_TIMEOUT_MS) {
+                    return copyImage(frame);
+                }
+                startWorker();
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            logger.warn("No fresh frame available for {} after {} ms", rtspUrl, FRAME_TIMEOUT_MS);
+            return copyImage(latestFrame);
+        }
+
+        private BufferedImage copyImage(BufferedImage source) {
+            if (source == null) {
+                return null;
+            }
+            BufferedImage copy = new BufferedImage(source.getWidth(), source.getHeight(), source.getType());
+            Graphics2D g = copy.createGraphics();
+            g.drawImage(source, 0, 0, null);
+            g.dispose();
+            return copy;
+        }
+
+        void runGrabber() {
+            logger.info("Starting RTSP grabber for {}", rtspUrl);
+            while (!shutdown.get() && !Thread.currentThread().isInterrupted()) {
+                try (FFmpegFrameGrabber grabber = createGrabber();
+                     Java2DFrameConverter converter = new Java2DFrameConverter()) {
+                    grabber.start();
+                    while (!shutdown.get() && !Thread.currentThread().isInterrupted()) {
+                        Frame frame = grabber.grabImage();
+                        if (frame == null) {
+                            break;
+                        }
+                        BufferedImage image = converter.convert(frame);
+                        if (image != null) {
+                            latestFrame = image;
+                            lastFrameTime.set(System.currentTimeMillis());
+                        }
+                    }
+                } catch (Exception e) {
+                    if (!shutdown.get()) {
+                        logger.warn("RTSP grabber error for {}: {}", rtspUrl, e.getMessage());
+                    }
+                }
+                if (!shutdown.get()) {
+                    try {
+                        Thread.sleep(GRABBER_ERROR_DELAY_MS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            }
+            logger.info("RTSP grabber stopped for {}", rtspUrl);
+        }
+
+        FFmpegFrameGrabber createGrabber() {
+            FFmpegFrameGrabber grabber = new FFmpegFrameGrabber(rtspUrl);
+            grabber.setOption("rtsp_transport", "tcp");
+            grabber.setOption("stimeout", "5000000");
+            grabber.setImageWidth(0);
+            grabber.setImageHeight(0);
+            grabber.setFrameRate(0);
+            return grabber;
+        }
+
+        void stop() {
+            Thread thread;
+            lock.lock();
+            try {
+                thread = workerThread;
+                workerThread = null;
+            } finally {
+                lock.unlock();
+            }
+            if (thread != null) {
+                thread.interrupt();
+            }
+        }
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/SharedData/EbedloData.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/EbedloData.java
@@ -1,0 +1,56 @@
+package com.keroleap.immerreader.SharedData;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.springframework.stereotype.Component;
+
+import com.keroleap.immerreader.EbedloRest;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class EbedloData {
+
+    private static final int SMOOTHING_WINDOW = 3;
+
+    private EbedloRest ebedloRest;
+    private final Deque<Boolean> recentOnDecisions = new ArrayDeque<>(SMOOTHING_WINDOW);
+
+    @PostConstruct
+    public void init() {
+        System.out.println("EbedloRest initialized at startup.");
+        this.ebedloRest = new EbedloRest();
+    }
+
+    public EbedloRest getEbedloRest() {
+        return ebedloRest;
+    }
+
+    public void setEbedloRest(EbedloRest ebedloRest) {
+        this.ebedloRest = ebedloRest;
+    }
+
+    public synchronized void addOnDecision(boolean on) {
+        if (recentOnDecisions.size() >= SMOOTHING_WINDOW) {
+            recentOnDecisions.pollFirst();
+        }
+        recentOnDecisions.offerLast(on);
+    }
+
+    public synchronized boolean getSmoothedOn() {
+        if (recentOnDecisions.isEmpty()) {
+            return false;
+        }
+        if (recentOnDecisions.size() < SMOOTHING_WINDOW) {
+            return recentOnDecisions.peekLast();
+        }
+        int trueCount = 0;
+        for (boolean decision : recentOnDecisions) {
+            if (decision) {
+                trueCount++;
+            }
+        }
+        return trueCount >= 2;
+    }
+}

--- a/src/main/java/com/keroleap/immerreader/SharedData/EbedloManagerData.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/EbedloManagerData.java
@@ -1,0 +1,137 @@
+package com.keroleap.immerreader.SharedData;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class EbedloManagerData {
+
+    private static final Logger logger = LoggerFactory.getLogger(EbedloManagerData.class);
+    private static final String DATA_FILE = "/data/ebedlo.properties";
+    private static final int POINT_COUNT = 10;
+    private static final int DEFAULT_THRESHOLD = 100;
+
+    private final AtomicIntegerArray xs = new AtomicIntegerArray(POINT_COUNT);
+    private final AtomicIntegerArray ys = new AtomicIntegerArray(POINT_COUNT);
+    private final AtomicInteger threshold = new AtomicInteger(DEFAULT_THRESHOLD);
+    private final AtomicBoolean enabled = new AtomicBoolean(true);
+
+    @PostConstruct
+    private void load() {
+        File file = new File(DATA_FILE);
+        if (file.exists()) {
+            Properties props = new Properties();
+            try (FileInputStream fis = new FileInputStream(file)) {
+                props.load(fis);
+                for (int i = 0; i < POINT_COUNT; i++) {
+                    xs.set(i, Integer.parseInt(props.getProperty("x" + i, "0")));
+                    ys.set(i, Integer.parseInt(props.getProperty("y" + i, "0")));
+                }
+                threshold.set(Integer.parseInt(props.getProperty("threshold", String.valueOf(DEFAULT_THRESHOLD))));
+                enabled.set(Boolean.parseBoolean(props.getProperty("enabled", "true")));
+            } catch (IOException | NumberFormatException e) {
+                logger.warn("Could not load Ebedlo data from {}: {}", DATA_FILE, e.getMessage());
+            }
+        }
+    }
+
+    private void save() {
+        Properties props = new Properties();
+        for (int i = 0; i < POINT_COUNT; i++) {
+            props.setProperty("x" + i, String.valueOf(xs.get(i)));
+            props.setProperty("y" + i, String.valueOf(ys.get(i)));
+        }
+        props.setProperty("threshold", String.valueOf(threshold.get()));
+        props.setProperty("enabled", String.valueOf(enabled.get()));
+        File file = new File(DATA_FILE);
+        File parent = file.getParentFile();
+        if (!parent.exists() && !parent.mkdirs()) {
+            logger.warn("Could not create directory {}", parent.getAbsolutePath());
+            return;
+        }
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            props.store(fos, null);
+        } catch (IOException e) {
+            logger.warn("Could not save Ebedlo data to {}: {}", DATA_FILE, e.getMessage());
+        }
+    }
+
+    public int getPointCount() {
+        return POINT_COUNT;
+    }
+
+    public int getX(int index) {
+        return xs.get(index);
+    }
+
+    public void setX(int index, int x) {
+        xs.set(index, x);
+        save();
+    }
+
+    public int getY(int index) {
+        return ys.get(index);
+    }
+
+    public void setY(int index, int y) {
+        ys.set(index, y);
+        save();
+    }
+
+    public int[] getXs() {
+        int[] result = new int[POINT_COUNT];
+        for (int i = 0; i < POINT_COUNT; i++) {
+            result[i] = xs.get(i);
+        }
+        return result;
+    }
+
+    public int[] getYs() {
+        int[] result = new int[POINT_COUNT];
+        for (int i = 0; i < POINT_COUNT; i++) {
+            result[i] = ys.get(i);
+        }
+        return result;
+    }
+
+    public void setPoints(int[] newXs, int[] newYs) {
+        if (newXs == null || newYs == null || newXs.length != POINT_COUNT || newYs.length != POINT_COUNT) {
+            throw new IllegalArgumentException("Expected " + POINT_COUNT + " x and y coordinates");
+        }
+        for (int i = 0; i < POINT_COUNT; i++) {
+            xs.set(i, newXs[i]);
+            ys.set(i, newYs[i]);
+        }
+        save();
+    }
+
+    public int getThreshold() {
+        return threshold.get();
+    }
+
+    public void setThreshold(int threshold) {
+        this.threshold.set(threshold);
+        save();
+    }
+
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled.set(enabled);
+        save();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 server.port=8099
+camera.ebedlo.url=rtsp://frigate:utcatapo@192.168.1.194:554/stream1

--- a/src/main/resources/templates/ebedlo-manager.html
+++ b/src/main/resources/templates/ebedlo-manager.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>Ariston Manager</title>
+    <title>Ebedlo Manager</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <style>
         * {
@@ -37,14 +37,13 @@
             display: flex;
             gap: 20px;
             align-items: flex-start;
-            padding: 0 20px;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
         }
         .controls {
             background: #16213e;
             padding: 20px;
             border-radius: 8px;
-            min-width: 250px;
+            min-width: 280px;
         }
         .form-group {
             margin-bottom: 15px;
@@ -83,6 +82,17 @@
         button.secondary.active {
             background: #28a745;
         }
+        button.point-btn {
+            width: auto;
+            margin: 2px;
+            padding: 8px 12px;
+        }
+        .point-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            margin-bottom: 10px;
+        }
         .image-container {
             background: #16213e;
             padding: 20px;
@@ -94,7 +104,7 @@
             display: inline-block;
         }
         img {
-            max-width: 800px;
+            max-width: 500px;
             border: 2px solid #0f3460;
             border-radius: 4px;
             display: block;
@@ -102,24 +112,36 @@
         }
         .marker {
             position: absolute;
-            width: 12px;
-            height: 12px;
+            width: 24px;
+            height: 24px;
             border-radius: 50%;
             border: 2px solid #fff;
             transform: translate(-50%, -50%);
             pointer-events: none;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 11px;
+            font-weight: bold;
+            color: white;
         }
-        .marker.start {
-            background: #28a745;
-        }
-        .marker.end {
+        .marker.point {
             background: #e94560;
+        }
+        .marker.point.active {
+            background: #28a745;
         }
         .current-values {
             margin-top: 15px;
             padding: 10px;
             background: #0f3460;
             border-radius: 4px;
+        }
+        .point-list {
+            max-height: 150px;
+            overflow-y: auto;
+            font-family: monospace;
+            font-size: 12px;
         }
         .status {
             margin-top: 10px;
@@ -161,6 +183,9 @@
             font-size: 24px;
             font-weight: bold;
             color: #e94560;
+        }
+        .data-card .value.active {
+            color: #28a745;
         }
         .error-stats {
             margin-top: 20px;
@@ -254,25 +279,34 @@
             color: #e94560;
             font-size: 16px;
         }
+        .threshold-hint {
+            font-size: 12px;
+            color: #aaa;
+            margin-top: 4px;
+        }
     </style>
 </head>
 <body>
     <nav>
         <a href="/">Home</a>
         <a href="/ImmerManager/adjust">Immer Manager</a>
-        <a href="/AristonManager/adjust" class="active">Ariston Manager</a>
-        <a href="/EbedloManager/adjust">Ebedlo Manager</a>
+        <a href="/AristonManager/adjust">Ariston Manager</a>
+        <a href="/EbedloManager/adjust" class="active">Ebedlo Manager</a>
     </nav>
 
-    <h1>Ariston Manager</h1>
+    <h1>Ebedlo Manager</h1>
 
     <div style="padding: 0 20px;">
         <div class="data-section" th:classappend="${!enabled} ? 'disabled-overlay' : ''">
             <h2>Detected Data</h2>
             <div class="data-grid">
                 <div class="data-card">
-                    <h3>Power Level</h3>
-                    <div class="value"><span id="percentage" th:text="${aristonRest.percentage}">0</span>%</div>
+                    <h3>Light</h3>
+                    <div class="value" id="light" th:classappend="${ebedloRest.on} ? 'active' : ''" th:text="${ebedloRest.on} ? 'ON' : 'OFF'">OFF</div>
+                </div>
+                <div class="data-card">
+                    <h3>Average Value</h3>
+                    <div class="value" id="averageValue">-</div>
                 </div>
             </div>
         </div>
@@ -293,50 +327,39 @@
                     <div id="controlsPanel" th:classappend="${!enabled} ? 'disabled-overlay' : ''">
                         <form id="pointForm">
                             <div class="form-group">
-                                <label for="startX">Start X:</label>
-                                <input type="number" id="startX" name="startX" th:value="${startX}" required>
+                                <label for="threshold">Brightness Threshold (HSV Value 0-255):</label>
+                                <input type="number" id="threshold" name="threshold" th:value="${threshold}" required>
+                                <div class="threshold-hint">Average HSV Value inside the polygon must be above this. Typical value: 80-150. Higher means brighter.</div>
                             </div>
+
                             <div class="form-group">
-                                <label for="startY">Start Y:</label>
-                                <input type="number" id="startY" name="startY" th:value="${startY}" required>
+                                <label>Active Point:</label>
+                                <div class="point-buttons" id="pointButtons"></div>
                             </div>
-                            <div class="form-group">
-                                <label for="endX">End X:</label>
-                                <input type="number" id="endX" name="endX" th:value="${endX}" required>
-                            </div>
-                            <div class="form-group">
-                                <label for="endY">End Y:</label>
-                                <input type="number" id="endY" name="endY" th:value="${endY}" required>
-                            </div>
-                            <button type="submit">Apply Points</button>
+
+                            <button type="submit">Apply Points &amp; Threshold</button>
                         </form>
 
-                        <button type="button" id="setStartBtn" class="secondary active">Set Start Point</button>
-                        <button type="button" id="setEndBtn" class="secondary">Set End Point</button>
-
                         <div class="current-values">
-                            <strong>Current Values:</strong><br>
-                            Start: (<span id="currentStartX" th:text="${startX}">0</span>, <span id="currentStartY" th:text="${startY}">0</span>)<br>
-                            End: (<span id="currentEndX" th:text="${endX}">0</span>, <span id="currentEndY" th:text="${endY}">0</span>)
+                            <strong>Current Points:</strong>
+                            <div class="point-list" id="pointList"></div>
                         </div>
                     </div>
 
                     <div id="stockPanel" class="stock-values" th:style="${enabled} ? 'display:none;' : ''">
                         <h3>Stock Values (Scheduler Disabled)</h3>
-                        <div>Power Level: 0%</div>
+                        <div>Light: OFF</div>
                     </div>
 
-                    <div id="status" class="status">Points updated!</div>
+                    <div id="status" class="status">Settings updated!</div>
                 </div>
 
                 <div class="image-container" th:classappend="${!enabled} ? 'disabled-overlay' : ''">
                     <h2>Live Preview</h2>
                     <div class="image-wrapper" id="imageWrapper">
-                        <img id="liveImage" src="/Ariston/uncroppedimage" alt="Ariston Camera Feed">
-                        <div id="startMarker" class="marker start" style="display:none;"></div>
-                        <div id="endMarker" class="marker end" style="display:none;"></div>
+                        <img id="liveImage" src="/Ebedlo/uncroppedimage" alt="Ebedlo Camera Feed">
                     </div>
-                    <p><small>Image refreshes automatically every 15 seconds. Click on image to set active point.</small></p>
+                    <p><small>Image refreshes automatically every 10 seconds. Click on image to set the active point.</small></p>
                 </div>
             </div>
         </div>
@@ -358,100 +381,131 @@
         </div>
     </div>
 
-    <script>
-        let activePoint = 'start';
+    <script th:inline="javascript">
+        const pointCount = /*[[${#lists.size(xs)}]]*/ 10;
+        const initialXs = /*[[${xs}]]*/ [];
+        const initialYs = /*[[${ys}]]*/ [];
+        let xs = [...initialXs];
+        let ys = [...initialYs];
+        let activePoint = 0;
 
-        const startXInput = document.getElementById('startX');
-        const startYInput = document.getElementById('startY');
-        const endXInput = document.getElementById('endX');
-        const endYInput = document.getElementById('endY');
-        const setStartBtn = document.getElementById('setStartBtn');
-        const setEndBtn = document.getElementById('setEndBtn');
+        const pointButtonsContainer = document.getElementById('pointButtons');
+        const pointList = document.getElementById('pointList');
         const liveImage = document.getElementById('liveImage');
         const imageWrapper = document.getElementById('imageWrapper');
-        const startMarker = document.getElementById('startMarker');
-        const endMarker = document.getElementById('endMarker');
+        const markers = [];
+
+        for (let i = 0; i < pointCount; i++) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'secondary point-btn';
+            btn.textContent = (i + 1);
+            btn.addEventListener('click', () => setActivePoint(i));
+            pointButtonsContainer.appendChild(btn);
+
+            const marker = document.createElement('div');
+            marker.className = 'marker point';
+            marker.textContent = (i + 1);
+            imageWrapper.appendChild(marker);
+            markers.push(marker);
+        }
+
+        function setActivePoint(index) {
+            activePoint = index;
+            updatePointButtons();
+        }
+
+        function updatePointButtons() {
+            const buttons = pointButtonsContainer.querySelectorAll('.point-btn');
+            buttons.forEach((btn, i) => {
+                if (i === activePoint) {
+                    btn.classList.add('active');
+                } else {
+                    btn.classList.remove('active');
+                }
+            });
+            updateMarkers();
+        }
+
+        function updatePointList() {
+            pointList.innerHTML = xs.map((x, i) => {
+                const active = i === activePoint ? ' &lt;- active' : '';
+                return `P${i + 1}: (${x}, ${ys[i]})${active}`;
+            }).join('<br>');
+        }
 
         function updateMarkers() {
-            const sx = parseInt(startXInput.value);
-            const sy = parseInt(startYInput.value);
-            const ex = parseInt(endXInput.value);
-            const ey = parseInt(endYInput.value);
-
             const rect = liveImage.getBoundingClientRect();
             const imgWidth = liveImage.naturalWidth || rect.width;
             const imgHeight = liveImage.naturalHeight || rect.height;
+            if (imgWidth === 0 || imgHeight === 0) {
+                return;
+            }
             const scaleX = rect.width / imgWidth;
             const scaleY = rect.height / imgHeight;
 
-            startMarker.style.left = (sx * scaleX) + 'px';
-            startMarker.style.top = (sy * scaleY) + 'px';
-            startMarker.style.display = 'block';
-
-            endMarker.style.left = (ex * scaleX) + 'px';
-            endMarker.style.top = (ey * scaleY) + 'px';
-            endMarker.style.display = 'block';
+            markers.forEach((marker, i) => {
+                marker.style.left = (xs[i] * scaleX) + 'px';
+                marker.style.top = (ys[i] * scaleY) + 'px';
+                marker.style.display = (xs[i] !== 0 || ys[i] !== 0) ? 'flex' : 'none';
+                if (i === activePoint) {
+                    marker.classList.add('active');
+                } else {
+                    marker.classList.remove('active');
+                }
+            });
+            updatePointList();
         }
 
         liveImage.addEventListener('load', updateMarkers);
-        if (liveImage.complete) updateMarkers();
-
-        setStartBtn.addEventListener('click', () => {
-            activePoint = 'start';
-            setStartBtn.classList.add('active');
-            setEndBtn.classList.remove('active');
+        liveImage.addEventListener('load', function() {
+            console.log('Ebedlo image loaded, size:', this.naturalWidth, 'x', this.naturalHeight);
         });
-
-        setEndBtn.addEventListener('click', () => {
-            activePoint = 'end';
-            setEndBtn.classList.add('active');
-            setStartBtn.classList.remove('active');
-        });
+        if (liveImage.complete) {
+            updateMarkers();
+        }
 
         imageWrapper.addEventListener('click', function(e) {
             const rect = liveImage.getBoundingClientRect();
             const imgWidth = liveImage.naturalWidth || rect.width;
             const imgHeight = liveImage.naturalHeight || rect.height;
+            if (imgWidth === 0 || imgHeight === 0 || rect.width === 0 || rect.height === 0) {
+                console.warn('Image has no size yet, cannot set point');
+                return;
+            }
             const scaleX = imgWidth / rect.width;
             const scaleY = imgHeight / rect.height;
 
             const x = Math.round((e.clientX - rect.left) * scaleX);
             const y = Math.round((e.clientY - rect.top) * scaleY);
 
-            if (activePoint === 'start') {
-                startXInput.value = x;
-                startYInput.value = y;
-            } else {
-                endXInput.value = x;
-                endYInput.value = y;
-            }
+            xs[activePoint] = x;
+            ys[activePoint] = y;
             updateMarkers();
         });
 
         document.getElementById('pointForm').addEventListener('submit', function(e) {
             e.preventDefault();
 
-            const startX = startXInput.value;
-            const startY = startYInput.value;
-            const endX = endXInput.value;
-            const endY = endYInput.value;
+            const points = xs.map((x, i) => `${x},${ys[i]}`).join(',');
+            const threshold = document.getElementById('threshold').value;
 
-            fetch('/AristonManager/set', {
+            fetch('/EbedloManager/set', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
                 },
-                body: `startX=${startX}&startY=${startY}&endX=${endX}&endY=${endY}`
+                body: `points=${encodeURIComponent(points)}&threshold=${threshold}`
             })
-            .then(response => response.json())
+            .then(response => {
+                if (!response.ok) {
+                    return response.text().then(text => { throw new Error(text); });
+                }
+                return response.json();
+            })
             .then(data => {
-                document.getElementById('currentStartX').textContent = data.startX;
-                document.getElementById('currentStartY').textContent = data.startY;
-                document.getElementById('currentEndX').textContent = data.endX;
-                document.getElementById('currentEndY').textContent = data.endY;
-
                 const status = document.getElementById('status');
-                status.textContent = 'Points updated!';
+                status.textContent = 'Points and threshold updated!';
                 status.className = 'status success';
                 setTimeout(() => {
                     status.className = 'status';
@@ -461,11 +515,14 @@
             })
             .catch(error => {
                 console.error('Error:', error);
+                const status = document.getElementById('status');
+                status.textContent = 'Error: ' + error.message;
+                status.className = 'status success';
             });
         });
 
         document.getElementById('schedulerToggle').addEventListener('change', function() {
-            fetch('/AristonManager/toggle', {
+            fetch('/EbedloManager/toggle', {
                 method: 'POST'
             })
             .then(response => response.json())
@@ -504,10 +561,33 @@
 
         function refreshImage() {
             const img = document.getElementById('liveImage');
-            img.src = '/Ariston/uncroppedimage?t=' + new Date().getTime();
+            const newSrc = '/Ebedlo/uncroppedimage?t=' + new Date().getTime();
+            img.src = newSrc;
+            console.log('Refreshing Ebedlo image:', newSrc);
         }
 
-        setInterval(refreshImage, 15000);
+        function fetchAverageValue() {
+            fetch('/Ebedlo/ebedlorestdata')
+                .then(response => response.json())
+                .then(data => {
+                    const averageValueElement = document.getElementById('averageValue');
+                    if (averageValueElement) {
+                        averageValueElement.textContent = data.averageValue != null ? data.averageValue : '-';
+                    }
+                    const lightElement = document.getElementById('light');
+                    if (lightElement) {
+                        lightElement.textContent = data.on ? 'ON' : 'OFF';
+                        lightElement.classList.toggle('active', data.on);
+                    }
+                })
+                .catch(error => {
+                    console.error('Error fetching Ebedlo data:', error);
+                });
+        }
+
+        setInterval(refreshImage, 10000);
+        setInterval(fetchAverageValue, 1000);
+        updatePointButtons();
     </script>
 </body>
 </html>

--- a/src/main/resources/templates/ebedlodata.html
+++ b/src/main/resources/templates/ebedlodata.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Ebedlo Data</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+</head>
+<body>
+    <div><span th:text="${message}"></span></div>
+    <img src="/Ebedlo/image" alt="Ebedlo">
+</body>
+</html>

--- a/src/main/resources/templates/immer-manager.html
+++ b/src/main/resources/templates/immer-manager.html
@@ -235,6 +235,7 @@
         <a href="/">Home</a>
         <a href="/ImmerManager/adjust" class="active">Immer Manager</a>
         <a href="/AristonManager/adjust">Ariston Manager</a>
+        <a href="/EbedloManager/adjust">Ebedlo Manager</a>
     </nav>
 
     <h1>Immer Manager</h1>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -106,6 +106,7 @@
         <a href="/" class="active">Home</a>
         <a href="/ImmerManager/adjust">Immer Manager</a>
         <a href="/AristonManager/adjust">Ariston Manager</a>
+        <a href="/EbedloManager/adjust">Ebedlo Manager</a>
     </nav>
 
     <div class="container">
@@ -124,6 +125,13 @@
                 <h2>Ariston Manager</h2>
                 <p>Configure and monitor your Ariston heating system with live camera feed and offset adjustment.</p>
                 <a href="/AristonManager/adjust">Open Ariston Manager</a>
+            </div>
+
+            <div class="card" th:classappend="${!ebedloEnabled} ? 'disabled-card' : ''">
+                <div class="status-badge" th:classappend="${ebedloEnabled} ? 'enabled' : 'disabled'" th:text="${ebedloEnabled} ? 'Enabled' : 'Disabled'">Enabled</div>
+                <h2>Ebedlo Manager</h2>
+                <p>Configure and monitor the Ebedlo RTSP camera with 10 light detection points.</p>
+                <a href="/EbedloManager/adjust">Open Ebedlo Manager</a>
             </div>
         </div>
     </div>

--- a/src/test/java/com/keroleap/immerreader/Controller/HomeControllerTest.java
+++ b/src/test/java/com/keroleap/immerreader/Controller/HomeControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.keroleap.immerreader.SharedData.AristonManagerData;
+import com.keroleap.immerreader.SharedData.EbedloManagerData;
 import com.keroleap.immerreader.SharedData.ImmerManagerData;
 
 import static org.mockito.Mockito.when;
@@ -25,37 +26,46 @@ class HomeControllerTest {
     @MockitoBean
     private AristonManagerData aristonManagerData;
 
+    @MockitoBean
+    private EbedloManagerData ebedloManagerData;
+
     @Test
-    void home_returnsIndexWithBothEnabled() throws Exception {
+    void home_returnsIndexWithAllEnabled() throws Exception {
         when(immerManagerData.isEnabled()).thenReturn(true);
         when(aristonManagerData.isEnabled()).thenReturn(true);
+        when(ebedloManagerData.isEnabled()).thenReturn(true);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("index"))
                 .andExpect(model().attribute("immerEnabled", true))
-                .andExpect(model().attribute("aristonEnabled", true));
+                .andExpect(model().attribute("aristonEnabled", true))
+                .andExpect(model().attribute("ebedloEnabled", true));
     }
 
     @Test
     void home_returnsIndexWithImmerDisabled() throws Exception {
         when(immerManagerData.isEnabled()).thenReturn(false);
         when(aristonManagerData.isEnabled()).thenReturn(true);
+        when(ebedloManagerData.isEnabled()).thenReturn(true);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/"))
                 .andExpect(status().isOk())
                 .andExpect(model().attribute("immerEnabled", false))
-                .andExpect(model().attribute("aristonEnabled", true));
+                .andExpect(model().attribute("aristonEnabled", true))
+                .andExpect(model().attribute("ebedloEnabled", true));
     }
 
     @Test
     void home_returnsIndexWithAristonDisabled() throws Exception {
         when(immerManagerData.isEnabled()).thenReturn(true);
         when(aristonManagerData.isEnabled()).thenReturn(false);
+        when(ebedloManagerData.isEnabled()).thenReturn(true);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/"))
                 .andExpect(status().isOk())
                 .andExpect(model().attribute("immerEnabled", true))
-                .andExpect(model().attribute("aristonEnabled", false));
+                .andExpect(model().attribute("aristonEnabled", false))
+                .andExpect(model().attribute("ebedloEnabled", true));
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a third monitored camera "Ebedlo" that reads from an RTSP stream and detects whether a bright tablecloth is present on a dark table.

## What's new

- **RTSP support**: a shared  and  handle both HTTP(S) JPEG snapshots and RTSP streams. The RTSP stream is opened once by a background thread and the latest frame is served from a cache, avoiding concurrent connection issues.
- **Ebedlo subsystem** following the same pattern as Immer/Ariston:
  -  with , , , 
  -  with set/toggle/get/adjust endpoints
  -  polling every 10 seconds
  -  persisting 10 points, HSV threshold and enabled flag to 
- **Detection logic**:
  - Uses a 10-point polygon to mark the tablecloth area
  - Computes the average HSV Value (0-255) of pixels inside the polygon
  - Trims the bottom/top 10% of pixel values to reduce noise from shadows, plates or reflections
  - Applies 3-sample majority smoothing before changing the ON/OFF state
- **UI**: new  with clickable polygon points, live preview refreshed every 10 seconds, current HSV value and error stats.
- **Navigation**: Ebedlo Manager link added to all page headers and the home page.
- **Docker**: runtime image switched from  to  because JavaCV native libraries require glibc.

## Configuration



## Notes

- The branch also contains the pre-existing  update.
- Tests were updated to mock the new  dependency in .

🤖 Generated with [Claude Code](https://claude.com/claude-code)