### PR TITLE
Fix error statistics UI count mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,7 @@ RUN mkdir -p /data
 VOLUME /data
 COPY --from=builder /app/target/immerreader-1.0.0.jar immerreader-1.0.0.jar
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8099/actuator/health || exit 1
+
 ENTRYPOINT ["java","-jar","/immerreader-1.0.0.jar"]

--- a/src/main/java/com/keroleap/immerreader/Scheduler/AristonScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/AristonScheduler.java
@@ -19,6 +19,7 @@ import com.keroleap.immerreader.Service.AristonAnalyzerService;
 import com.keroleap.immerreader.SharedData.AristonData;
 import com.keroleap.immerreader.SharedData.AristonManagerData;
 import com.keroleap.immerreader.SharedData.ErrorStatistics;
+import com.keroleap.immerreader.SharedData.SchedulerHealthTracker;
 
 import jakarta.annotation.PreDestroy;
 
@@ -44,6 +45,9 @@ public class AristonScheduler {
 
     @Autowired
     private ErrorStatistics errorStatistics;
+
+    @Autowired
+    private SchedulerHealthTracker schedulerHealthTracker;
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final AtomicInteger consecutiveErrors = new AtomicInteger(0);
@@ -76,6 +80,7 @@ public class AristonScheduler {
             aristonData.setAristonRest(result);
             consecutiveErrors.set(0);
             lastErrorType = null;
+            schedulerHealthTracker.recordSuccess("Ariston");
         } catch (TimeoutException e) {
             future.cancel(true);
             logger.warn("Timeout fetching Ariston data, keeping previous value.");
@@ -88,6 +93,7 @@ public class AristonScheduler {
 
     private void handleError(ErrorType errorType) {
         errorStatistics.recordError("Ariston", errorType);
+        schedulerHealthTracker.recordError("Ariston", errorType);
         if (errorType.equals(lastErrorType)) {
             consecutiveErrors.incrementAndGet();
         } else {

--- a/src/main/java/com/keroleap/immerreader/Scheduler/ImmerScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/ImmerScheduler.java
@@ -19,6 +19,7 @@ import com.keroleap.immerreader.Service.ImmerAnalyzerService;
 import com.keroleap.immerreader.SharedData.ImmerData;
 import com.keroleap.immerreader.SharedData.ImmerManagerData;
 import com.keroleap.immerreader.SharedData.ErrorStatistics;
+import com.keroleap.immerreader.SharedData.SchedulerHealthTracker;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -42,6 +43,9 @@ public class ImmerScheduler {
 
     @Autowired
     private ErrorStatistics errorStatistics;
+
+    @Autowired
+    private SchedulerHealthTracker schedulerHealthTracker;
 
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private final AtomicInteger currentDelayMs = new AtomicInteger(DEFAULT_DELAY_MS);
@@ -93,6 +97,7 @@ public class ImmerScheduler {
         consecutiveErrors.set(0);
         lastErrorType = null;
         currentDelayMs.set(DEFAULT_DELAY_MS);
+        schedulerHealthTracker.recordSuccess("Immer");
         scheduleNextRead();
     }
 
@@ -105,6 +110,7 @@ public class ImmerScheduler {
 
     private void handleError(ErrorType errorType) {
         errorStatistics.recordError("Immer", errorType);
+        schedulerHealthTracker.recordError("Immer", errorType);
         if (errorType.equals(lastErrorType)) {
             consecutiveErrors.incrementAndGet();
         } else {

--- a/src/main/java/com/keroleap/immerreader/SharedData/ErrorStatistics.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/ErrorStatistics.java
@@ -20,9 +20,7 @@ public class ErrorStatistics {
     }
 
     public void recordError(String system, ErrorType errorType) {
-        String key = system + ":" + errorType.name();
-        errorCounts.computeIfAbsent(key, k -> new ErrorCounter()).increment();
-        cleanup();
+        recordError(system, errorType.name().toLowerCase());
     }
 
     public void recordError(String system, String errorType) {

--- a/src/main/java/com/keroleap/immerreader/SharedData/SchedulerHealthTracker.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/SchedulerHealthTracker.java
@@ -1,0 +1,94 @@
+package com.keroleap.immerreader.SharedData;
+
+import java.time.LocalTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import com.keroleap.immerreader.ErrorType;
+
+@Component
+public class SchedulerHealthTracker implements HealthIndicator {
+
+    private static final int CONSECUTIVE_TIMEOUT_THRESHOLD = 50;
+    private static final String[] TRACKED_SYSTEMS = { "Ariston", "Immer" };
+    private static final LocalTime NIGHT_START = LocalTime.of(20, 55);
+    private static final LocalTime NIGHT_END = LocalTime.of(9, 5);
+
+    private final Map<String, ConsecutiveErrorState> states = new ConcurrentHashMap<>();
+
+    public SchedulerHealthTracker() {
+        for (String system : TRACKED_SYSTEMS) {
+            states.put(system, new ConsecutiveErrorState());
+        }
+    }
+
+    public void recordError(String system, ErrorType errorType) {
+        ConsecutiveErrorState state = states.get(system);
+        if (state == null) {
+            return;
+        }
+        if (errorType == ErrorType.TIMEOUT) {
+            state.increment();
+        } else {
+            state.reset();
+        }
+    }
+
+    public void recordSuccess(String system) {
+        ConsecutiveErrorState state = states.get(system);
+        if (state != null) {
+            state.reset();
+        }
+    }
+
+    @Override
+    public Health health() {
+        boolean healthy = true;
+        boolean nightWindow = isNightWindow();
+        Health.Builder builder = Health.up();
+        for (Map.Entry<String, ConsecutiveErrorState> entry : states.entrySet()) {
+            String system = entry.getKey();
+            int count = entry.getValue().getCount();
+            builder.withDetail(system + "ConsecutiveTimeouts", count);
+            boolean thresholdExceeded = count >= CONSECUTIVE_TIMEOUT_THRESHOLD;
+            if (thresholdExceeded && !nightWindow) {
+                healthy = false;
+                builder.down()
+                        .withDetail(system + "Status", "DOWN: " + count + " consecutive timeouts");
+            } else if (thresholdExceeded) {
+                builder.withDetail(system + "Status", "UP (night silence): " + count + " consecutive timeouts");
+            } else {
+                builder.withDetail(system + "Status", "UP: " + count + " consecutive timeouts");
+            }
+        }
+        return healthy ? builder.build() : builder.build();
+    }
+
+    private boolean isNightWindow() {
+        LocalTime now = LocalTime.now();
+        if (now.isAfter(NIGHT_START) || now.isBefore(NIGHT_END)) {
+            return true;
+        }
+        return false;
+    }
+
+    private static class ConsecutiveErrorState {
+        private int count;
+
+        synchronized void increment() {
+            count++;
+        }
+
+        synchronized void reset() {
+            count = 0;
+        }
+
+        synchronized int getCount() {
+            return count;
+        }
+    }
+}

--- a/src/test/java/com/keroleap/immerreader/Scheduler/AristonSchedulerTest.java
+++ b/src/test/java/com/keroleap/immerreader/Scheduler/AristonSchedulerTest.java
@@ -12,6 +12,7 @@ import com.keroleap.immerreader.AristonRest;
 import com.keroleap.immerreader.Service.AristonAnalyzerService;
 import com.keroleap.immerreader.SharedData.AristonManagerData;
 import com.keroleap.immerreader.SharedData.ErrorStatistics;
+import com.keroleap.immerreader.SharedData.SchedulerHealthTracker;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -26,6 +27,9 @@ class AristonSchedulerTest {
 
     @Mock
     private ErrorStatistics errorStatistics;
+
+    @Mock
+    private SchedulerHealthTracker schedulerHealthTracker;
 
     @InjectMocks
     private AristonScheduler aristonScheduler;


### PR DESCRIPTION
Fixes the problem where timeout errors appeared in the console log but the manager UI error counters stayed at zero.

## Root cause
 stored keys using the raw enum name, e.g. . The Thymeleaf manager templates, however, look up the counts with lowercase keys:  and . Because the keys never matched, logged errors never incremented the UI counters.

## Fix
Normalize  names to lowercase when recording, so the stored key () matches what the templates expect. The existing  overload is reused so both enum and string recordings behave consistently.

## Verification
- [INFO] Scanning for projects...
[INFO] 
[INFO] ----------------------< com.keroleap:immerreader >----------------------
[INFO] Building immerreader 1.0.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- clean:3.4.1:clean (default-clean) @ immerreader ---
[INFO] Deleting /home/kero/Dokumentumok/Development/Code/ImmerReader/target
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ immerreader ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] Copying 7 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.13.0:compile (default-compile) @ immerreader ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 27 source files with javac [debug parameters release 25] to target/classes
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ immerreader ---
[INFO] skip non existing resourceDirectory /home/kero/Dokumentumok/Development/Code/ImmerReader/src/test/resources
[INFO] 
[INFO] --- compiler:3.13.0:testCompile (default-testCompile) @ immerreader ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 14 source files with javac [debug parameters release 25] to target/test-classes
[INFO] 
[INFO] --- surefire:3.5.3:test (default-test) @ immerreader ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.keroleap.immerreader.AristonRestTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.030 s -- in com.keroleap.immerreader.AristonRestTest
[INFO] Running com.keroleap.immerreader.ImmerRestTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.keroleap.immerreader.ImmerRestTest
[INFO] Running com.keroleap.immerreader.ImmerreaderApplicationTests
23:21:05.543 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [com.keroleap.immerreader.ImmerreaderApplicationTests]: ImmerreaderApplicationTests does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
23:21:05.602 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.ImmerreaderApplicationTests

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-14T23:21:05.797+02:00  INFO 175097 --- [           main] c.k.i.ImmerreaderApplicationTests        : Starting ImmerreaderApplicationTests using Java 25.0.4 with PID 175097 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-14T23:21:05.798+02:00  INFO 175097 --- [           main] c.k.i.ImmerreaderApplicationTests        : No active profile set, falling back to 1 default profile: "default"
AristonRest initialized at startup.
EbedloRest initialized at startup.
ImmerRest initialized at startup.
2026-08-14T23:21:06.321+02:00  INFO 175097 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-14T23:21:06.569+02:00  INFO 175097 --- [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
2026-08-14T23:21:06.599+02:00  INFO 175097 --- [           main] c.k.i.ImmerreaderApplicationTests        : Started ImmerreaderApplicationTests in 0.94 seconds (process running for 1.497)
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.573 s -- in com.keroleap.immerreader.ImmerreaderApplicationTests
[INFO] Running com.keroleap.immerreader.Controller.HelloWorldControllerTest
2026-08-14T23:21:07.053+02:00  INFO 175097 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.HelloWorldControllerTest]: HelloWorldControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-14T23:21:07.068+02:00  INFO 175097 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.HelloWorldControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-14T23:21:07.085+02:00  INFO 175097 --- [           main] c.k.i.C.HelloWorldControllerTest         : Starting HelloWorldControllerTest using Java 25.0.4 with PID 175097 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-14T23:21:07.086+02:00  INFO 175097 --- [           main] c.k.i.C.HelloWorldControllerTest         : No active profile set, falling back to 1 default profile: "default"
2026-08-14T23:21:07.301+02:00  INFO 175097 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-14T23:21:07.356+02:00  INFO 175097 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-14T23:21:07.356+02:00  INFO 175097 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-14T23:21:07.357+02:00  INFO 175097 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-14T23:21:07.366+02:00  INFO 175097 --- [           main] c.k.i.C.HelloWorldControllerTest         : Started HelloWorldControllerTest in 0.296 seconds (process running for 2.264)
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.402 s -- in com.keroleap.immerreader.Controller.HelloWorldControllerTest
[INFO] Running com.keroleap.immerreader.Controller.AristonControllerTest
2026-08-14T23:21:07.457+02:00  INFO 175097 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.AristonControllerTest]: AristonControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-14T23:21:07.463+02:00  INFO 175097 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.AristonControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-14T23:21:07.480+02:00  INFO 175097 --- [           main] c.k.i.Controller.AristonControllerTest   : Starting AristonControllerTest using Java 25.0.4 with PID 175097 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-14T23:21:07.480+02:00  INFO 175097 --- [           main] c.k.i.Controller.AristonControllerTest   : No active profile set, falling back to 1 default profile: "default"
2026-08-14T23:21:07.625+02:00  INFO 175097 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-14T23:21:07.650+02:00  INFO 175097 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-14T23:21:07.650+02:00  INFO 175097 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-14T23:21:07.651+02:00  INFO 175097 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 1 ms
2026-08-14T23:21:07.654+02:00  INFO 175097 --- [           main] c.k.i.Controller.AristonControllerTest   : Started AristonControllerTest in 0.189 seconds (process running for 2.552)
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.215 s -- in com.keroleap.immerreader.Controller.AristonControllerTest
[INFO] Running com.keroleap.immerreader.Controller.ImmerManagerControllerTest
2026-08-14T23:21:07.673+02:00  INFO 175097 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.ImmerManagerControllerTest]: ImmerManagerControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-14T23:21:07.678+02:00  INFO 175097 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.ImmerManagerControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-14T23:21:07.689+02:00  INFO 175097 --- [           main] c.k.i.C.ImmerManagerControllerTest       : Starting ImmerManagerControllerTest using Java 25.0.4 with PID 175097 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-14T23:21:07.689+02:00  INFO 175097 --- [           main] c.k.i.C.ImmerManagerControllerTest       : No active profile set, falling back to 1 default profile: "default"
2026-08-14T23:21:07.745+02:00  INFO 175097 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-14T23:21:07.769+02:00  INFO 175097 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-14T23:21:07.769+02:00  INFO 175097 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-14T23:21:07.769+02:00  INFO 175097 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-14T23:21:07.772+02:00  INFO 175097 --- [           main] c.k.i.C.ImmerManagerControllerTest       : Started ImmerManagerControllerTest in 0.092 seconds (process running for 2.67)
2026-08-14T23:21:07.803+02:00  WARN 175097 --- [           main] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.web.bind.MissingServletRequestParameterException: Required request parameter 'y' for method parameter type int is not present]
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.144 s -- in com.keroleap.immerreader.Controller.ImmerManagerControllerTest
[INFO] Running com.keroleap.immerreader.Controller.AristonManagerControllerTest
2026-08-14T23:21:07.818+02:00  INFO 175097 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.AristonManagerControllerTest]: AristonManagerControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-14T23:21:07.822+02:00  INFO 175097 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.AristonManagerControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-14T23:21:07.832+02:00  INFO 175097 --- [           main] c.k.i.C.AristonManagerControllerTest     : Starting AristonManagerControllerTest using Java 25.0.4 with PID 175097 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-14T23:21:07.832+02:00  INFO 175097 --- [           main] c.k.i.C.AristonManagerControllerTest     : No active profile set, falling back to 1 default profile: "default"
2026-08-14T23:21:07.883+02:00  INFO 175097 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-14T23:21:07.906+02:00  INFO 175097 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-14T23:21:07.906+02:00  INFO 175097 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-14T23:21:07.907+02:00  INFO 175097 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 1 ms
2026-08-14T23:21:07.909+02:00  INFO 175097 --- [           main] c.k.i.C.AristonManagerControllerTest     : Started AristonManagerControllerTest in 0.085 seconds (process running for 2.807)
2026-08-14T23:21:07.945+02:00  WARN 175097 --- [           main] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.web.bind.MissingServletRequestParameterException: Required request parameter 'endY' for method parameter type int is not present]
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.132 s -- in com.keroleap.immerreader.Controller.AristonManagerControllerTest
[INFO] Running com.keroleap.immerreader.Controller.HomeControllerTest
2026-08-14T23:21:07.952+02:00  INFO 175097 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.HomeControllerTest]: HomeControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-14T23:21:07.956+02:00  INFO 175097 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.HomeControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-14T23:21:07.966+02:00  INFO 175097 --- [           main] c.k.i.Controller.HomeControllerTest      : Starting HomeControllerTest using Java 25.0.4 with PID 175097 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-14T23:21:07.966+02:00  INFO 175097 --- [           main] c.k.i.Controller.HomeControllerTest      : No active profile set, falling back to 1 default profile: "default"
2026-08-14T23:21:08.048+02:00  INFO 175097 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-14T23:21:08.069+02:00  INFO 175097 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-14T23:21:08.069+02:00  INFO 175097 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-14T23:21:08.069+02:00  INFO 175097 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-14T23:21:08.072+02:00  INFO 175097 --- [           main] c.k.i.Controller.HomeControllerTest      : Started HomeControllerTest in 0.115 seconds (process running for 2.97)
2026-08-14T23:21:08.176+02:00  INFO 175097 --- [194_554_stream1] c.k.i.Service.RtspFrameGrabber           : Starting RTSP grabber for rtsp://frigate:utcatapo@192.168.1.194:554/stream1
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.296 s -- in com.keroleap.immerreader.Controller.HomeControllerTest
[INFO] Running com.keroleap.immerreader.SharedData.ImmerManagerDataTest
2026-08-14T23:21:08.249+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.251+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.251+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.251+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.252+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.252+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.252+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.253+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.253+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.253+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.253+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.254+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-14T23:21:08.254+02:00  WARN 175097 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.keroleap.immerreader.SharedData.ImmerManagerDataTest
[INFO] Running com.keroleap.immerreader.SharedData.AristonManagerDataTest
2026-08-14T23:21:08.255+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.256+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.256+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.256+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.256+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.257+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.258+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.258+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.259+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.259+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.259+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.259+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.259+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.260+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.260+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.261+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-14T23:21:08.261+02:00  WARN 175097 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.keroleap.immerreader.SharedData.AristonManagerDataTest
[INFO] Running com.keroleap.immerreader.Service.AristonAnalyzerServiceTest
2026-08-14T23:21:08.318+02:00  WARN 175097 --- [pool-6-thread-1] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.320+02:00  WARN 175097 --- [pool-6-thread-1] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.071 s -- in com.keroleap.immerreader.Service.AristonAnalyzerServiceTest
[INFO] Running com.keroleap.immerreader.Service.ImmerAnalyzerServiceTest
2026-08-14T23:21:08.336+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.337+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.337+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.341+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.341+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.342+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.342+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.342+02:00  WARN 175097 --- [194_554_stream1] c.k.i.Service.RtspFrameGrabber           : RTSP grabber error for rtsp://frigate:utcatapo@192.168.1.194:554/stream1: avformat_open_input() error -1: Could not open input "rtsp://frigate:utcatapo@192.168.1.194:554/stream1". (Has setFormat() been called?) (For more details, make sure FFmpegLogCallback.set() has been called.)
2026-08-14T23:21:08.344+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.344+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.344+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: truefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.345+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.345+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.346+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-14T23:21:08.346+02:00  WARN 175097 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in com.keroleap.immerreader.Service.ImmerAnalyzerServiceTest
[INFO] Running com.keroleap.immerreader.Scheduler.ImmerSchedulerTest
2026-08-14T23:21:08.359+02:00  INFO 175097 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
2026-08-14T23:21:08.362+02:00  INFO 175097 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
2026-08-14T23:21:08.362+02:00  INFO 175097 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
2026-08-14T23:21:08.365+02:00  INFO 175097 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s -- in com.keroleap.immerreader.Scheduler.ImmerSchedulerTest
[INFO] Running com.keroleap.immerreader.Scheduler.AristonSchedulerTest
2026-08-14T23:21:08.372+02:00  INFO 175097 --- [           main] c.k.i.Scheduler.AristonScheduler         : Shutting down AristonScheduler executor.
2026-08-14T23:21:08.376+02:00 ERROR 175097 --- [           main] c.k.i.Scheduler.AristonScheduler         : Error fetching Ariston data: Cannot invoke "com.keroleap.immerreader.SharedData.AristonData.setAristonRest(com.keroleap.immerreader.AristonRest)" because "this.aristonData" is null
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in com.keroleap.immerreader.Scheduler.AristonSchedulerTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 97, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jar:3.4.2:jar (default-jar) @ immerreader ---
[INFO] Building jar: /home/kero/Dokumentumok/Development/Code/ImmerReader/target/immerreader-1.0.0.jar
[INFO] 
[INFO] --- spring-boot:3.4.5:repackage (repackage) @ immerreader ---
[INFO] Replacing main artifact /home/kero/Dokumentumok/Development/Code/ImmerReader/target/immerreader-1.0.0.jar with repackaged archive, adding nested dependencies in BOOT-INF/.
[INFO] The original artifact has been renamed to /home/kero/Dokumentumok/Development/Code/ImmerReader/target/immerreader-1.0.0.jar.original
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.243 s
[INFO] Finished at: 2026-08-14T23:21:13+02:00
[INFO] ------------------------------------------------------------------------ passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)