### PR TITLE
Improve Chicken egg detection with Otsu thresholding, debug overlay and contour analytics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
 			<artifactId>ffmpeg-platform</artifactId>
 			<version>7.1-1.5.11</version>
 		</dependency>
+		<dependency>
+			<groupId>org.bytedeco</groupId>
+			<artifactId>opencv-platform</artifactId>
+			<version>4.10.0-1.5.11</version>
+		</dependency>
  </dependencies>
 
 	<build>
@@ -68,6 +73,9 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<jvmArguments>--enable-native-access=ALL-UNNAMED</jvmArguments>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/keroleap/immerreader/ChickenRest.java
+++ b/src/main/java/com/keroleap/immerreader/ChickenRest.java
@@ -9,6 +9,7 @@ public class ChickenRest {
     private int totalCount;
     private boolean error;
     private ErrorType errorType;
+    private int intervalSeconds;
 
     public List<Integer> getNestCounts() {
         return nestCounts;
@@ -40,6 +41,14 @@ public class ChickenRest {
 
     public void setErrorType(ErrorType errorType) {
         this.errorType = errorType;
+    }
+
+    public int getIntervalSeconds() {
+        return intervalSeconds;
+    }
+
+    public void setIntervalSeconds(int intervalSeconds) {
+        this.intervalSeconds = intervalSeconds;
     }
 
     @Override

--- a/src/main/java/com/keroleap/immerreader/Controller/ChickenController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/ChickenController.java
@@ -3,6 +3,8 @@ package com.keroleap.immerreader.Controller;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import javax.imageio.ImageIO;
 
@@ -52,8 +54,32 @@ public class ChickenController {
     @GetMapping(value = "/debugimage", produces = MediaType.IMAGE_JPEG_VALUE)
     public @ResponseBody byte[] getDebugImage() throws IOException {
         BufferedImage image = chickenAnalyzerService.getBufferedImage(cameraUrl);
-        image = chickenAnalyzerService.drawDebugOverlay(image, chickenManagerData);
+        try {
+            image = chickenAnalyzerService.drawDebugOverlay(image, chickenManagerData);
+        } catch (Throwable t) {
+            image = createErrorImage(t.getClass().getSimpleName() + ": " + t.getMessage());
+        }
         return writeJpeg(image);
+    }
+
+    private BufferedImage createErrorImage(String message) {
+        BufferedImage errorImage = new BufferedImage(640, 160, BufferedImage.TYPE_INT_RGB);
+        java.awt.Graphics2D g = errorImage.createGraphics();
+        g.setColor(java.awt.Color.BLACK);
+        g.fillRect(0, 0, 640, 160);
+        g.setColor(java.awt.Color.RED);
+        g.fillRect(0, 120, 640, 40);
+        g.setColor(java.awt.Color.WHITE);
+        g.setFont(new java.awt.Font("Arial", java.awt.Font.BOLD, 16));
+        g.drawString("DEBUG OVERLAY ERROR", 20, 30);
+        g.setFont(new java.awt.Font("Arial", java.awt.Font.PLAIN, 14));
+        if (message != null) {
+            g.drawString(message, 20, 70);
+        }
+        g.setColor(java.awt.Color.BLACK);
+        g.drawString("Check server logs / camera configuration", 20, 145);
+        g.dispose();
+        return errorImage;
     }
 
     private byte[] writeJpeg(BufferedImage image) throws IOException {
@@ -74,5 +100,11 @@ public class ChickenController {
     @ResponseBody
     public ChickenRest getChickenRestData() {
         return chickenData.getChickenRest();
+    }
+
+    @RequestMapping(value = "/contourdata")
+    @ResponseBody
+    public List<Map<String, Object>> getContourData() {
+        return chickenAnalyzerService.getLastContourData();
     }
 }

--- a/src/main/java/com/keroleap/immerreader/Controller/ChickenController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/ChickenController.java
@@ -46,6 +46,12 @@ public class ChickenController {
     @GetMapping(value = "/uncroppedimage", produces = MediaType.IMAGE_JPEG_VALUE)
     public @ResponseBody byte[] getUncroppedImage() throws IOException {
         BufferedImage image = chickenAnalyzerService.getBufferedImage(cameraUrl);
+        return writeJpeg(image);
+    }
+
+    @GetMapping(value = "/debugimage", produces = MediaType.IMAGE_JPEG_VALUE)
+    public @ResponseBody byte[] getDebugImage() throws IOException {
+        BufferedImage image = chickenAnalyzerService.getBufferedImage(cameraUrl);
         image = chickenAnalyzerService.drawDebugOverlay(image, chickenManagerData);
         return writeJpeg(image);
     }

--- a/src/main/java/com/keroleap/immerreader/Controller/ChickenManagerController.java
+++ b/src/main/java/com/keroleap/immerreader/Controller/ChickenManagerController.java
@@ -42,12 +42,18 @@ public class ChickenManagerController {
                                       @RequestParam String minAreas,
                                       @RequestParam String maxAreas,
                                       @RequestParam String minCircularities,
+                                      @RequestParam(required = false, defaultValue = "") String autoThresholds,
+                                      @RequestParam(required = false, defaultValue = "") String thresholdMasks,
+                                      @RequestParam(required = false, defaultValue = "") String otsuOffsets,
                                       @RequestParam(required = false, defaultValue = "30") int intervalSeconds) {
         String[] pointParts = points.split(",");
         String[] thresholdParts = thresholds.split(",");
         String[] minAreaParts = minAreas.split(",");
         String[] maxAreaParts = maxAreas.split(",");
         String[] circularityParts = minCircularities.split(",");
+        String[] autoThresholdParts = autoThresholds.isEmpty() ? new String[0] : autoThresholds.split(",");
+        String[] thresholdMaskParts = thresholdMasks.isEmpty() ? new String[0] : thresholdMasks.split(",");
+        String[] otsuOffsetParts = otsuOffsets.isEmpty() ? new String[0] : otsuOffsets.split(",");
 
         if (count < 1 || count > 5) {
             return ResponseEntity.badRequest().body("Nest count must be between 1 and 5.");
@@ -74,14 +80,21 @@ public class ChickenManagerController {
                 int minArea = Integer.parseInt(minAreaParts[i].trim());
                 int maxArea = Integer.parseInt(maxAreaParts[i].trim());
                 double minCircularity = Double.parseDouble(circularityParts[i].trim());
+                boolean autoThreshold = autoThresholdParts.length > i ? Boolean.parseBoolean(autoThresholdParts[i].trim()) : true;
+                boolean thresholdMask = thresholdMaskParts.length > i ? Boolean.parseBoolean(thresholdMaskParts[i].trim()) : false;
+                int otsuOffset = otsuOffsetParts.length > i ? Integer.parseInt(otsuOffsetParts[i].trim()) : 0;
 
                 chickenManagerData.setNestPoints(i, xs, ys);
                 chickenManagerData.setNestThreshold(i, threshold);
-                chickenManagerData.setNestFilters(i, minArea, maxArea, minCircularity);
+                chickenManagerData.setNestFilters(i, minArea, maxArea, minCircularity, autoThreshold, thresholdMask, otsuOffset);
             }
             chickenData.setConfiguredCount(count);
             chickenManagerData.setIntervalSeconds(intervalSeconds);
-            return ResponseEntity.ok(chickenManagerData.getNests());
+            chickenData.setIntervalSeconds(intervalSeconds);
+            Map<String, Object> response = new HashMap<>();
+            response.put("nests", chickenManagerData.getNests());
+            response.put("intervalSeconds", intervalSeconds);
+            return ResponseEntity.ok(response);
         } catch (NumberFormatException e) {
             return ResponseEntity.badRequest().body("Invalid number format: " + e.getMessage());
         }
@@ -114,6 +127,15 @@ public class ChickenManagerController {
         return response;
     }
 
+    @PostMapping("/toggleThresholdMask")
+    @ResponseBody
+    public Map<String, Object> toggleThresholdMask() {
+        chickenManagerData.setThresholdMaskEnabled(!chickenManagerData.isThresholdMaskEnabled());
+        Map<String, Object> response = new HashMap<>();
+        response.put("thresholdMaskEnabled", chickenManagerData.isThresholdMaskEnabled());
+        return response;
+    }
+
     @GetMapping
     public ModelAndView adjust() {
         ModelAndView modelAndView = new ModelAndView("chicken-manager");
@@ -128,6 +150,7 @@ public class ChickenManagerController {
 
     private void addCommonAttributes(ModelAndView modelAndView) {
         modelAndView.addObject("enabled", chickenManagerData.isEnabled());
+        modelAndView.addObject("thresholdMaskEnabled", chickenManagerData.isThresholdMaskEnabled());
         modelAndView.addObject("nestCount", chickenManagerData.getNestCount());
         modelAndView.addObject("chickenRest", chickenData.getChickenRest());
         List<ChickenNest> nests = chickenManagerData.getNests();

--- a/src/main/java/com/keroleap/immerreader/Scheduler/ChickenScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/ChickenScheduler.java
@@ -90,6 +90,7 @@ public class ChickenScheduler {
             }
             List<Integer> counts = rest.getNestCounts();
             chickenData.setConfiguredCount(counts.size());
+            chickenData.setIntervalSeconds(chickenManagerData.getIntervalSeconds());
             chickenData.addCounts(counts);
             consecutiveErrors.set(0);
             lastErrorType = null;

--- a/src/main/java/com/keroleap/immerreader/Service/ChickenAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/ChickenAnalyzerService.java
@@ -52,7 +52,7 @@ public class ChickenAnalyzerService {
         List<ChickenNest> nests = managerData.getNests();
         for (ChickenNest nest : nests) {
             if (nest.isConfigured()) {
-                counts.add(countEggsInNest(image, nest));
+                counts.add(countEggsInNest(image, nest, null));
             } else {
                 counts.add(0);
             }
@@ -78,15 +78,17 @@ public class ChickenAnalyzerService {
             }
             int[] xs = nest.getXs();
             int[] ys = nest.getYs();
-            graphics.setColor(new Color(NEST_COLORS[i % NEST_COLORS.length]));
+            Color color = new Color(NEST_COLORS[i % NEST_COLORS.length]);
+            graphics.setColor(color);
             graphics.drawPolygon(xs, ys, xs.length);
             graphics.drawString("F" + (i + 1), xs[0] + 4, ys[0] + 16);
+            countEggsInNest(copy, nest, graphics);
         }
         graphics.dispose();
         return copy;
     }
 
-    private int countEggsInNest(BufferedImage image, ChickenNest nest) {
+    private int countEggsInNest(BufferedImage image, ChickenNest nest, Graphics2D debugGraphics) {
         int[] xs = nest.getXs();
         int[] ys = nest.getYs();
         Rectangle bounds = computeBounds(xs, ys, image.getWidth(), image.getHeight());
@@ -119,11 +121,13 @@ public class ChickenAnalyzerService {
                 Mat contour = contours.get(i);
                 double area = opencv_imgproc.contourArea(contour);
                 if (area < nest.getMinArea() || area > nest.getMaxArea()) {
+                    drawDebugContour(debugGraphics, contour, bounds, Color.YELLOW);
                     continue;
                 }
                 double perimeter = opencv_imgproc.arcLength(contour, true);
                 double circularity = perimeter > 0 ? 4 * Math.PI * area / (perimeter * perimeter) : 0;
                 if (circularity < nest.getMinCircularity()) {
+                    drawDebugContour(debugGraphics, contour, bounds, Color.ORANGE);
                     continue;
                 }
                 int[] center = contourCenter(contour);
@@ -131,6 +135,10 @@ public class ChickenAnalyzerService {
                 int imageY = bounds.y + center[1];
                 if (polygon.contains(imageX, imageY)) {
                     count++;
+                    drawDebugContour(debugGraphics, contour, bounds, Color.GREEN);
+                    drawDebugCenter(debugGraphics, imageX, imageY, Color.GREEN);
+                } else {
+                    drawDebugContour(debugGraphics, contour, bounds, Color.RED);
                 }
             }
 
@@ -138,6 +146,33 @@ public class ChickenAnalyzerService {
         } finally {
             gray.release();
         }
+    }
+
+    private void drawDebugContour(Graphics2D graphics, Mat contour, Rectangle bounds, Color color) {
+        if (graphics == null) {
+            return;
+        }
+        java.awt.Polygon poly = new java.awt.Polygon();
+        Rect rect = opencv_imgproc.boundingRect(contour);
+        int cx = rect.x();
+        int cy = rect.y();
+        int cw = rect.width();
+        int ch = rect.height();
+        poly.addPoint(bounds.x + cx, bounds.y + cy);
+        poly.addPoint(bounds.x + cx + cw, bounds.y + cy);
+        poly.addPoint(bounds.x + cx + cw, bounds.y + cy + ch);
+        poly.addPoint(bounds.x + cx, bounds.y + cy + ch);
+        graphics.setColor(color);
+        graphics.setStroke(new BasicStroke(2));
+        graphics.drawPolygon(poly);
+    }
+
+    private void drawDebugCenter(Graphics2D graphics, int x, int y, Color color) {
+        if (graphics == null) {
+            return;
+        }
+        graphics.setColor(color);
+        graphics.fillOval(x - 4, y - 4, 8, 8);
     }
 
     private Rectangle computeBounds(int[] xs, int[] ys, int maxWidth, int maxHeight) {

--- a/src/main/java/com/keroleap/immerreader/Service/ChickenAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/ChickenAnalyzerService.java
@@ -1,13 +1,17 @@
 package com.keroleap.immerreader.Service;
 
+import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
+import java.nio.IntBuffer;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_imgproc;
@@ -31,7 +35,16 @@ public class ChickenAnalyzerService {
     private static final Logger logger = LoggerFactory.getLogger(ChickenAnalyzerService.class);
     private static final int BLUR_SIZE = 5;
     private static final int MORPH_SIZE = 3;
-    private static final int[] NEST_COLORS = { 16711680, 65280, 255, 16776960, 16711935 };
+    private static final Color NEST_POLYGON_COLOR = new Color(0, 140, 255);
+    private static final Color REJECTED_CONTOUR_COLOR = new Color(200, 100, 0);
+    private static final Color MERGED_CONTOUR_COLOR = new Color(180, 0, 220);
+    private static final Color THRESHOLD_MASK_COLOR = new Color(0, 255, 0, 255);
+    private static final float THRESHOLD_MASK_ALPHA = 0.4f;
+    private static final double MERGED_ASPECT_RATIO_THRESHOLD = 1.8;
+    private static final double MERGED_HULL_RATIO_THRESHOLD = 1.25;
+    private static final int AGGRESSIVE_SPLIT_DISTANCE_THRESHOLD = 64;
+
+    private final List<Map<String, Object>> accumulatedContourData = java.util.Collections.synchronizedList(new ArrayList<>());
 
     @Autowired
     private CameraImageService cameraImageService;
@@ -50,9 +63,10 @@ public class ChickenAnalyzerService {
 
         List<Integer> counts = new ArrayList<>();
         List<ChickenNest> nests = managerData.getNests();
-        for (ChickenNest nest : nests) {
+        for (int i = 0; i < nests.size(); i++) {
+            ChickenNest nest = nests.get(i);
             if (nest.isConfigured()) {
-                counts.add(countEggsInNest(image, nest, null));
+                counts.add(countEggsInNest(image, nest, null, i, false));
             } else {
                 counts.add(0);
             }
@@ -67,10 +81,22 @@ public class ChickenAnalyzerService {
         if (image == null) {
             return createPlaceholderImage();
         }
+        long start = System.currentTimeMillis();
         BufferedImage copy = deepCopy(image);
         Graphics2D graphics = copy.createGraphics();
         graphics.setStroke(new BasicStroke(3));
+        graphics.setFont(new java.awt.Font("Arial", java.awt.Font.BOLD, 14));
         List<ChickenNest> nests = managerData.getNests();
+
+        accumulatedContourData.clear();
+
+        BufferedImage thresholdMaskLayer = createThresholdMaskLayer(copy, nests, managerData.isThresholdMaskEnabled());
+        if (thresholdMaskLayer != null) {
+            graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, THRESHOLD_MASK_ALPHA));
+            graphics.drawImage(thresholdMaskLayer, 0, 0, null);
+            graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 1.0f));
+        }
+
         for (int i = 0; i < nests.size(); i++) {
             ChickenNest nest = nests.get(i);
             if (!nest.isConfigured()) {
@@ -78,17 +104,104 @@ public class ChickenAnalyzerService {
             }
             int[] xs = nest.getXs();
             int[] ys = nest.getYs();
-            Color color = new Color(NEST_COLORS[i % NEST_COLORS.length]);
-            graphics.setColor(color);
+            graphics.setColor(NEST_POLYGON_COLOR);
             graphics.drawPolygon(xs, ys, xs.length);
-            graphics.drawString("F" + (i + 1), xs[0] + 4, ys[0] + 16);
-            countEggsInNest(copy, nest, graphics);
+            countEggsInNest(copy, nest, graphics, i, true);
+            String label = "F" + (i + 1);
+            if (nest.isAutoThreshold()) {
+                int otsuThreshold = computeOtsuThresholdForPolygon(copy, nest);
+                label += " Otsu:" + otsuThreshold + "+" + nest.getOtsuOffset();
+            }
+            graphics.drawString(label, xs[0] + 4, ys[0] + 18);
         }
         graphics.dispose();
+        logger.info("Debug overlay rendered in {} ms", System.currentTimeMillis() - start);
         return copy;
     }
 
-    private int countEggsInNest(BufferedImage image, ChickenNest nest, Graphics2D debugGraphics) {
+    private BufferedImage createThresholdMaskLayer(BufferedImage source, List<ChickenNest> nests, boolean globalEnabled) {
+        if (!globalEnabled) {
+            return null;
+        }
+        BufferedImage maskLayer = new BufferedImage(source.getWidth(), source.getHeight(), BufferedImage.TYPE_INT_ARGB);
+        int maskColor = THRESHOLD_MASK_COLOR.getRGB();
+        for (ChickenNest nest : nests) {
+            if (!nest.isConfigured()) {
+                continue;
+            }
+            int[] xs = nest.getXs();
+            int[] ys = nest.getYs();
+            Rectangle bounds = computeBounds(xs, ys, source.getWidth(), source.getHeight());
+            if (bounds.width <= 0 || bounds.height <= 0) {
+                continue;
+            }
+            Polygon polygon = new Polygon(xs, ys, xs.length);
+            Mat mask = computeThresholdMaskMat(source, nest, bounds);
+            try {
+                for (int y = 0; y < bounds.height; y++) {
+                    for (int x = 0; x < bounds.width; x++) {
+                        int imageX = bounds.x + x;
+                        int imageY = bounds.y + y;
+                        if (polygon.contains(imageX, imageY)) {
+                            byte[] pixel = new byte[1];
+                            mask.ptr(y, x).get(pixel);
+                            if ((pixel[0] & 0xFF) == 255) {
+                                maskLayer.setRGB(imageX, imageY, maskColor);
+                            }
+                        }
+                    }
+                }
+            } finally {
+                mask.release();
+            }
+        }
+        return maskLayer;
+    }
+
+    private Mat computeThresholdMaskMat(BufferedImage image, ChickenNest nest, Rectangle bounds) {
+        Mat gray = bufferedImageToGrayMat(image, bounds);
+        Mat blurred = new Mat();
+        Mat binary = new Mat();
+        Mat kernel = null;
+        Mat closed = new Mat();
+        Mat opened = new Mat();
+        try {
+            opencv_imgproc.GaussianBlur(gray, blurred, new Size(BLUR_SIZE, BLUR_SIZE), 0);
+            int effectiveThreshold = nest.isAutoThreshold() ? computeOtsuThreshold(blurred) : nest.getThreshold();
+            opencv_imgproc.threshold(blurred, binary, effectiveThreshold, 255, opencv_imgproc.THRESH_BINARY);
+            kernel = opencv_imgproc.getStructuringElement(opencv_imgproc.MORPH_ELLIPSE, new Size(MORPH_SIZE, MORPH_SIZE));
+            opencv_imgproc.morphologyEx(binary, closed, opencv_imgproc.MORPH_CLOSE, kernel);
+            opencv_imgproc.morphologyEx(closed, opened, opencv_imgproc.MORPH_OPEN, kernel);
+            return opened.clone();
+        } finally {
+            gray.release();
+            blurred.release();
+            binary.release();
+            if (kernel != null) {
+                kernel.release();
+            }
+            closed.release();
+            opened.release();
+        }
+    }
+
+    private int computeOtsuThresholdForPolygon(BufferedImage image, ChickenNest nest) {
+        int[] xs = nest.getXs();
+        int[] ys = nest.getYs();
+        Rectangle bounds = computeBounds(xs, ys, image.getWidth(), image.getHeight());
+        if (bounds.width <= 0 || bounds.height <= 0) {
+            return nest.getThreshold();
+        }
+        Mat gray = bufferedImageToGrayMat(image, bounds);
+        try {
+            return computeOtsuThreshold(gray);
+        } finally {
+            gray.release();
+        }
+    }
+
+    private int countEggsInNest(BufferedImage image, ChickenNest nest, Graphics2D debugGraphics, int nestIndex, boolean countMergedAsTwo) {
+        java.util.concurrent.atomic.AtomicInteger nestIndexRef = new java.util.concurrent.atomic.AtomicInteger(nestIndex);
         int[] xs = nest.getXs();
         int[] ys = nest.getYs();
         Rectangle bounds = computeBounds(xs, ys, image.getWidth(), image.getHeight());
@@ -98,53 +211,353 @@ public class ChickenAnalyzerService {
 
         Polygon polygon = new Polygon(xs, ys, xs.length);
         Mat gray = bufferedImageToGrayMat(image, bounds);
+        Mat blurred = new Mat();
+        Mat binary = new Mat();
+        Mat kernel = null;
+        Mat closed = new Mat();
+        Mat opened = new Mat();
+        MatVector contours = new MatVector();
+        Mat hierarchy = new Mat();
         try {
-            Mat blurred = new Mat();
             opencv_imgproc.GaussianBlur(gray, blurred, new Size(BLUR_SIZE, BLUR_SIZE), 0);
 
-            Mat binary = new Mat();
-            opencv_imgproc.threshold(blurred, binary, nest.getThreshold(), 255, opencv_imgproc.THRESH_BINARY);
+            int otsuThreshold = computeOtsuThreshold(blurred);
+            int effectiveThreshold = nest.isAutoThreshold() ? Math.max(1, Math.min(254, otsuThreshold + nest.getOtsuOffset())) : nest.getThreshold();
+            opencv_imgproc.threshold(blurred, binary, effectiveThreshold, 255, opencv_imgproc.THRESH_BINARY);
 
-            Mat kernel = opencv_imgproc.getStructuringElement(opencv_imgproc.MORPH_ELLIPSE, new Size(MORPH_SIZE, MORPH_SIZE));
-            Mat closed = new Mat();
+            kernel = opencv_imgproc.getStructuringElement(opencv_imgproc.MORPH_ELLIPSE, new Size(MORPH_SIZE, MORPH_SIZE));
             opencv_imgproc.morphologyEx(binary, closed, opencv_imgproc.MORPH_CLOSE, kernel);
-            Mat opened = new Mat();
             opencv_imgproc.morphologyEx(closed, opened, opencv_imgproc.MORPH_OPEN, kernel);
 
-            MatVector contours = new MatVector();
-            Mat hierarchy = new Mat();
             opencv_imgproc.findContours(opened, contours, hierarchy, opencv_imgproc.RETR_EXTERNAL, opencv_imgproc.CHAIN_APPROX_SIMPLE);
 
+            List<Mat> eggContours = splitEggsWithWatershed(opened, gray, contours, nest, nest.getMinArea());
             int count = 0;
-            long contourCount = contours.size();
-            for (int i = 0; i < contourCount; i++) {
-                Mat contour = contours.get(i);
-                double area = opencv_imgproc.contourArea(contour);
-                if (area < nest.getMinArea() || area > nest.getMaxArea()) {
-                    drawDebugContour(debugGraphics, contour, bounds, Color.YELLOW);
-                    continue;
+            List<Map<String, Object>> contourData = new ArrayList<>();
+            for (Mat contour : eggContours) {
+                boolean merged = isMergedContour(contour, polygon, bounds);
+                if (merged) {
+                    List<Mat> split = aggressivelySplitContour(opened, contour, nest);
+                    if (split.size() >= 2) {
+                        logger.info("Aggressive split separated merged contour into {} parts", split.size());
+                        for (Mat part : split) {
+                            Map<String, Object> partInfo = analyzeContour(part, bounds, polygon, nest, false, nestIndexRef);
+                            double partArea = ((Number) partInfo.get("area")).doubleValue();
+                            if (partArea >= nest.getMinArea()) {
+                                partInfo.put("countedAs", 1);
+                                if (evaluateContourFromInfo(part, bounds, polygon, nest, debugGraphics, partInfo)) {
+                                    count++;
+                                }
+                                contourData.add(partInfo);
+                            }
+                            part.release();
+                        }
+                        contour.release();
+                        continue;
+                    }
+                    for (Mat part : split) {
+                        part.release();
+                    }
                 }
-                double perimeter = opencv_imgproc.arcLength(contour, true);
-                double circularity = perimeter > 0 ? 4 * Math.PI * area / (perimeter * perimeter) : 0;
-                if (circularity < nest.getMinCircularity()) {
-                    drawDebugContour(debugGraphics, contour, bounds, Color.ORANGE);
-                    continue;
+                Map<String, Object> contourInfo = analyzeContour(contour, bounds, polygon, nest, merged, nestIndexRef);
+                double contourArea = ((Number) contourInfo.get("area")).doubleValue();
+                if (contourArea >= nest.getMinArea()) {
+                    contourInfo.put("countedAs", 1);
+                    boolean counted = evaluateContourFromInfo(contour, bounds, polygon, nest, debugGraphics, contourInfo);
+                    contourData.add(contourInfo);
+                    if (counted) {
+                        count++;
+                        if (countMergedAsTwo && merged) {
+                            count++;
+                            contourInfo.put("countedAs", 2);
+                        }
+                    }
                 }
-                int[] center = contourCenter(contour);
-                int imageX = bounds.x + center[0];
-                int imageY = bounds.y + center[1];
-                if (polygon.contains(imageX, imageY)) {
-                    count++;
-                    drawDebugContour(debugGraphics, contour, bounds, Color.GREEN);
-                    drawDebugCenter(debugGraphics, imageX, imageY, Color.GREEN);
-                } else {
-                    drawDebugContour(debugGraphics, contour, bounds, Color.RED);
-                }
+                contour.release();
+            }
+            synchronized (accumulatedContourData) {
+                accumulatedContourData.addAll(contourData);
             }
 
             return count;
         } finally {
             gray.release();
+            blurred.release();
+            binary.release();
+            if (kernel != null) {
+                kernel.release();
+            }
+            closed.release();
+            opened.release();
+            hierarchy.release();
+        }
+    }
+
+    public List<Map<String, Object>> getLastContourData() {
+        synchronized (accumulatedContourData) {
+            return new ArrayList<>(accumulatedContourData);
+        }
+    }
+
+    private List<Mat> splitEggsWithWatershed(Mat binary, Mat gray, MatVector initialContours, ChickenNest nest, double minArea) {
+        List<Mat> result = new ArrayList<>();
+        long count = initialContours.size();
+        if (count == 0) {
+            return result;
+        }
+
+        Mat distance = new Mat();
+        Mat distance8u = new Mat();
+        Mat sureFg = new Mat();
+        MatVector fgContours = new MatVector();
+        Mat fgHierarchy = new Mat();
+        try {
+            // Distance transform to find peaks inside foreground blobs
+            opencv_imgproc.distanceTransform(binary, distance, opencv_imgproc.DIST_L2, 5);
+            opencv_core.normalize(distance, distance, 0.0, 255.0, opencv_core.NORM_MINMAX, -1, new Mat());
+            distance.convertTo(distance8u, opencv_core.CV_8U, 1.0, 0.0);
+
+            // Foreground = distance peaks above 50% of normalized range
+            opencv_imgproc.threshold(distance8u, sureFg, 127, 255, opencv_imgproc.THRESH_BINARY);
+
+            opencv_imgproc.findContours(sureFg, fgContours, fgHierarchy, opencv_imgproc.RETR_EXTERNAL, opencv_imgproc.CHAIN_APPROX_SIMPLE);
+
+            long splitCount = fgContours.size();
+            List<Mat> filtered = new ArrayList<>();
+            for (int i = 0; i < splitCount; i++) {
+                Mat c = fgContours.get(i);
+                if (opencv_imgproc.contourArea(c) >= minArea) {
+                    filtered.add(c.clone());
+                }
+                c.release();
+            }
+            if (!filtered.isEmpty() && filtered.size() > count) {
+                logger.info("Split {} original egg contours into {} distance-peak contours", count, filtered.size());
+                result.addAll(filtered);
+            } else {
+                for (Mat m : filtered) {
+                    m.release();
+                }
+                for (int i = 0; i < count; i++) {
+                    result.add(initialContours.get(i).clone());
+                }
+            }
+            return result;
+        } catch (Throwable t) {
+            logger.warn("Egg splitting failed, using original contours: {}", t.getMessage());
+            result.clear();
+            for (int i = 0; i < count; i++) {
+                result.add(initialContours.get(i).clone());
+            }
+            return result;
+        } finally {
+            distance.release();
+            distance8u.release();
+            sureFg.release();
+            fgHierarchy.release();
+        }
+    }
+
+    private Map<String, Object> analyzeContour(Mat contour, Rectangle bounds, Polygon polygon, ChickenNest nest, boolean merged, java.util.concurrent.atomic.AtomicInteger nestIndexRef) {
+        Map<String, Object> info = new LinkedHashMap<>();
+        Rect rect = opencv_imgproc.boundingRect(contour);
+        double area = opencv_imgproc.contourArea(contour);
+        double perimeter = opencv_imgproc.arcLength(contour, true);
+        double circularity = perimeter > 0 ? 4 * Math.PI * area / (perimeter * perimeter) : 0;
+        double insideRatio = contourInsidePolygonRatio(contour, bounds, polygon);
+        int w = rect.width();
+        int h = rect.height();
+        double aspectRatio = (w > 0 && h > 0) ? (double) Math.max(w, h) / Math.min(w, h) : 0;
+        Mat hull = new Mat();
+        double hullRatio = 1.0;
+        try {
+            opencv_imgproc.convexHull(contour, hull, false, true);
+            double hullArea = opencv_imgproc.contourArea(hull);
+            if (hullArea > 0 && area > 0) {
+                hullRatio = hullArea / area;
+            }
+        } finally {
+            hull.release();
+        }
+        info.put("nest", nestIndexRef != null ? "F" + (nestIndexRef.get() + 1) : "?");
+        info.put("x", bounds.x + rect.x());
+        info.put("y", bounds.y + rect.y());
+        info.put("width", w);
+        info.put("height", h);
+        info.put("area", (int) area);
+        info.put("perimeter", (int) perimeter);
+        info.put("circularity", Math.round(circularity * 1000.0) / 1000.0);
+        info.put("insideRatio", Math.round(insideRatio * 1000.0) / 1000.0);
+        info.put("aspectRatio", Math.round(aspectRatio * 1000.0) / 1000.0);
+        info.put("hullRatio", Math.round(hullRatio * 1000.0) / 1000.0);
+        info.put("minArea", nest.getMinArea());
+        info.put("maxArea", nest.getMaxArea());
+        info.put("minCircularity", nest.getMinCircularity());
+        info.put("otsuOffset", nest.getOtsuOffset());
+        info.put("merged", merged);
+        info.put("counted", false);
+        return info;
+    }
+
+    private boolean evaluateContourFromInfo(Mat contour, Rectangle bounds, Polygon polygon, ChickenNest nest, Graphics2D debugGraphics, Map<String, Object> info) {
+        boolean merged = Boolean.TRUE.equals(info.get("merged"));
+        double area = ((Number) info.get("area")).doubleValue();
+        double circularity = ((Number) info.get("circularity")).doubleValue();
+        double insideRatio = ((Number) info.get("insideRatio")).doubleValue();
+        if (area < nest.getMinArea() || area > nest.getMaxArea()) {
+            if (area >= nest.getMinArea()) {
+                drawDebugContour(debugGraphics, contour, bounds, merged ? MERGED_CONTOUR_COLOR : REJECTED_CONTOUR_COLOR);
+            }
+            return false;
+        }
+        if (circularity < nest.getMinCircularity()) {
+            drawDebugContour(debugGraphics, contour, bounds, merged ? MERGED_CONTOUR_COLOR : REJECTED_CONTOUR_COLOR);
+            return false;
+        }
+        if (insideRatio >= 0.5) {
+            Color color = merged ? MERGED_CONTOUR_COLOR : Color.GREEN;
+            drawDebugContour(debugGraphics, contour, bounds, color);
+            if (merged) {
+                drawDebugMergedLabel(debugGraphics, contour, bounds, "Merged?");
+            }
+            int[] center = contourInsideCentroid(contour, bounds, polygon);
+            drawDebugCenter(debugGraphics, center[0], center[1], color);
+            info.put("counted", true);
+            return true;
+        }
+        if (debugGraphics != null) {
+            drawDebugContour(debugGraphics, contour, bounds, merged ? MERGED_CONTOUR_COLOR : REJECTED_CONTOUR_COLOR);
+        }
+        return false;
+    }
+
+
+    private boolean isMergedContour(Mat contour, Polygon polygon, Rectangle bounds) {
+        double area = opencv_imgproc.contourArea(contour);
+        if (area <= 0) {
+            return false;
+        }
+        Rect rect = opencv_imgproc.boundingRect(contour);
+        int w = rect.width();
+        int h = rect.height();
+        if (w <= 0 || h <= 0) {
+            return false;
+        }
+        double aspectRatio = (double) Math.max(w, h) / Math.min(w, h);
+        if (aspectRatio >= MERGED_ASPECT_RATIO_THRESHOLD) {
+            return true;
+        }
+        Mat hull = new Mat();
+        try {
+            opencv_imgproc.convexHull(contour, hull, false, true);
+            double hullArea = opencv_imgproc.contourArea(hull);
+            if (hullArea > 0 && hullArea / area >= MERGED_HULL_RATIO_THRESHOLD) {
+                return true;
+            }
+        } finally {
+            hull.release();
+        }
+        return false;
+    }
+
+    private List<Mat> aggressivelySplitContour(Mat opened, Mat contour, ChickenNest nest) {
+        List<Mat> result = new ArrayList<>();
+        Rect rect = opencv_imgproc.boundingRect(contour);
+        int x = rect.x();
+        int y = rect.y();
+        int w = rect.width();
+        int h = rect.height();
+        if (w <= 0 || h <= 0) {
+            result.add(contour.clone());
+            return result;
+        }
+
+        int imgW = opened.cols();
+        int imgH = opened.rows();
+        int x0 = Math.max(0, x);
+        int y0 = Math.max(0, y);
+        int x1 = Math.min(imgW, x + w);
+        int y1 = Math.min(imgH, y + h);
+        int roiW = x1 - x0;
+        int roiH = y1 - y0;
+        if (roiW <= 0 || roiH <= 0) {
+            result.add(contour.clone());
+            return result;
+        }
+
+        org.bytedeco.opencv.opencv_core.Rect roiRect = new org.bytedeco.opencv.opencv_core.Rect(x0, y0, roiW, roiH);
+        Mat roi = new Mat(opened, roiRect);
+        Mat distance = new Mat();
+        Mat distance8u = new Mat();
+        Mat sureFg = new Mat();
+        MatVector fgContours = new MatVector();
+        Mat fgHierarchy = new Mat();
+        try {
+            opencv_imgproc.distanceTransform(roi, distance, opencv_imgproc.DIST_L2, 5);
+            opencv_core.normalize(distance, distance, 0.0, 255.0, opencv_core.NORM_MINMAX, -1, new Mat());
+            distance.convertTo(distance8u, opencv_core.CV_8U, 1.0, 0.0);
+            opencv_imgproc.threshold(distance8u, sureFg, AGGRESSIVE_SPLIT_DISTANCE_THRESHOLD, 255, opencv_imgproc.THRESH_BINARY);
+            opencv_imgproc.findContours(sureFg, fgContours, fgHierarchy, opencv_imgproc.RETR_EXTERNAL, opencv_imgproc.CHAIN_APPROX_SIMPLE);
+
+            long splitCount = fgContours.size();
+            if (splitCount >= 2) {
+                for (int i = 0; i < splitCount; i++) {
+                    Mat part = fgContours.get(i);
+                    Mat shifted = shiftContour(part, x0, y0);
+                    result.add(shifted);
+                    part.release();
+                }
+            } else {
+                if (splitCount == 1) {
+                    fgContours.get(0).release();
+                }
+                result.add(contour.clone());
+            }
+        } catch (Throwable t) {
+            logger.warn("Aggressive contour split failed: {}", t.getMessage());
+            result.clear();
+            result.add(contour.clone());
+        } finally {
+            distance.release();
+            distance8u.release();
+            sureFg.release();
+            fgHierarchy.release();
+        }
+        return result;
+    }
+
+    private Mat shiftContour(Mat contour, int dx, int dy) {
+        Mat shifted = new Mat(contour.rows(), contour.cols(), contour.type());
+        IntBuffer src = contour.createBuffer();
+        IntBuffer dst = shifted.createBuffer();
+        int total = src.remaining();
+        for (int i = 0; i < total; i += 2) {
+            dst.put(i, src.get(i) + dx);
+            dst.put(i + 1, src.get(i + 1) + dy);
+        }
+        return shifted;
+    }
+
+    private void drawDebugMergedLabel(Graphics2D graphics, Mat contour, Rectangle bounds, String text) {
+        if (graphics == null) {
+            return;
+        }
+        Rect rect = opencv_imgproc.boundingRect(contour);
+        int x = bounds.x + rect.x();
+        int y = bounds.y + rect.y();
+        graphics.setColor(Color.WHITE);
+        graphics.setFont(new java.awt.Font("Arial", java.awt.Font.BOLD, 12));
+        graphics.drawString(text, x, Math.max(12, y - 4));
+    }
+
+    private int computeOtsuThreshold(Mat gray) {
+        try {
+            double otsu = opencv_imgproc.threshold(gray, new Mat(), 0, 255, opencv_imgproc.THRESH_BINARY + opencv_imgproc.THRESH_OTSU);
+            int result = (int) otsu;
+            return Math.max(1, Math.min(254, result));
+        } catch (Throwable t) {
+            logger.warn("Otsu threshold computation failed: {}", t.getMessage());
+            return 180;
         }
     }
 
@@ -198,6 +611,60 @@ public class ChickenAnalyzerService {
         int cx = rect.x() + rect.width() / 2;
         int cy = rect.y() + rect.height() / 2;
         return new int[] { cx, cy };
+    }
+
+    private double contourInsidePolygonRatio(Mat contour, Rectangle bounds, Polygon polygon) {
+        Rect rect = opencv_imgproc.boundingRect(contour);
+        int x0 = rect.x();
+        int y0 = rect.y();
+        int w = rect.width();
+        int h = rect.height();
+        if (w <= 0 || h <= 0) {
+            return 0;
+        }
+
+        int insidePixels = 0;
+        int totalPixels = 0;
+        int step = Math.max(1, Math.min(w, h) / 20);
+        for (int dy = 0; dy < h; dy += step) {
+            for (int dx = 0; dx < w; dx += step) {
+                int imageX = bounds.x + x0 + dx;
+                int imageY = bounds.y + y0 + dy;
+                if (polygon.contains(imageX, imageY)) {
+                    insidePixels++;
+                }
+                totalPixels++;
+            }
+        }
+        return totalPixels > 0 ? (double) insidePixels / totalPixels : 0;
+    }
+
+    private int[] contourInsideCentroid(Mat contour, Rectangle bounds, Polygon polygon) {
+        Rect rect = opencv_imgproc.boundingRect(contour);
+        int x0 = rect.x();
+        int y0 = rect.y();
+        int w = rect.width();
+        int h = rect.height();
+
+        long sumX = 0;
+        long sumY = 0;
+        int count = 0;
+        int step = Math.max(1, Math.min(w, h) / 20);
+        for (int dy = 0; dy < h; dy += step) {
+            for (int dx = 0; dx < w; dx += step) {
+                int imageX = bounds.x + x0 + dx;
+                int imageY = bounds.y + y0 + dy;
+                if (polygon.contains(imageX, imageY)) {
+                    sumX += imageX;
+                    sumY += imageY;
+                    count++;
+                }
+            }
+        }
+        if (count == 0) {
+            return new int[] { bounds.x + x0 + w / 2, bounds.y + y0 + h / 2 };
+        }
+        return new int[] { (int) (sumX / count), (int) (sumY / count) };
     }
 
     private Mat bufferedImageToGrayMat(BufferedImage image, Rectangle bounds) {

--- a/src/main/java/com/keroleap/immerreader/SharedData/ChickenData.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/ChickenData.java
@@ -19,6 +19,7 @@ public class ChickenData {
     private ChickenRest chickenRest = new ChickenRest();
     private final List<Deque<Integer>> history = new ArrayList<>();
     private int configuredCount = 0;
+    private int intervalSeconds = 30;
 
     public ChickenData() {
         resizeHistory(3);
@@ -42,16 +43,25 @@ public class ChickenData {
         ChickenRest rest = new ChickenRest();
         rest.setNestCounts(smoothed);
         rest.setTotalCount(smoothed.stream().mapToInt(Integer::intValue).sum());
+        rest.setIntervalSeconds(this.intervalSeconds);
         this.chickenRest = rest;
     }
 
     public synchronized ChickenRest getChickenRest() {
+        chickenRest.setIntervalSeconds(this.intervalSeconds);
         return chickenRest;
     }
 
     public synchronized void setConfiguredCount(int count) {
         this.configuredCount = count;
         resizeHistory(count);
+    }
+
+    public synchronized void setIntervalSeconds(int intervalSeconds) {
+        this.intervalSeconds = intervalSeconds;
+        if (this.chickenRest != null) {
+            this.chickenRest.setIntervalSeconds(intervalSeconds);
+        }
     }
 
     private void resizeHistory(int count) {

--- a/src/main/java/com/keroleap/immerreader/SharedData/ChickenManagerData.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/ChickenManagerData.java
@@ -29,6 +29,7 @@ public class ChickenManagerData {
     private int nestCount = 3;
     private int intervalSeconds = DEFAULT_INTERVAL_SECONDS;
     private boolean enabled = false;
+    private boolean thresholdMaskEnabled = false;
 
     public ChickenManagerData() {
         load();
@@ -57,6 +58,15 @@ public class ChickenManagerData {
         save();
     }
 
+    public boolean isThresholdMaskEnabled() {
+        return thresholdMaskEnabled;
+    }
+
+    public void setThresholdMaskEnabled(boolean thresholdMaskEnabled) {
+        this.thresholdMaskEnabled = thresholdMaskEnabled;
+        save();
+    }
+
     public int getIntervalSeconds() {
         return intervalSeconds;
     }
@@ -80,18 +90,22 @@ public class ChickenManagerData {
         save();
     }
 
-    public void setNestFilters(int index, int minArea, int maxArea, double minCircularity) {
+    public void setNestFilters(int index, int minArea, int maxArea, double minCircularity, boolean autoThreshold, boolean thresholdMask, int otsuOffset) {
         validateIndex(index);
         ChickenNest nest = nests.get(index);
         nest.setMinArea(minArea);
         nest.setMaxArea(maxArea);
         nest.setMinCircularity(minCircularity);
+        nest.setAutoThreshold(autoThreshold);
+        nest.setThresholdMask(thresholdMask);
+        nest.setOtsuOffset(otsuOffset);
         save();
     }
 
     public void save() {
         Properties properties = new Properties();
         properties.setProperty("enabled", String.valueOf(enabled));
+        properties.setProperty("thresholdMaskEnabled", String.valueOf(thresholdMaskEnabled));
         properties.setProperty("intervalSeconds", String.valueOf(intervalSeconds));
         properties.setProperty("nestCount", String.valueOf(nestCount));
         for (int i = 0; i < nestCount; i++) {
@@ -107,6 +121,9 @@ public class ChickenManagerData {
             properties.setProperty(prefix + "minArea", String.valueOf(nest.getMinArea()));
             properties.setProperty(prefix + "maxArea", String.valueOf(nest.getMaxArea()));
             properties.setProperty(prefix + "minCircularity", String.valueOf(nest.getMinCircularity()));
+            properties.setProperty(prefix + "autoThreshold", String.valueOf(nest.isAutoThreshold()));
+            properties.setProperty(prefix + "thresholdMask", String.valueOf(nest.isThresholdMask()));
+            properties.setProperty(prefix + "otsuOffset", String.valueOf(nest.getOtsuOffset()));
         }
 
         File file = new File(DATA_FILE);
@@ -129,6 +146,7 @@ public class ChickenManagerData {
         try (InputStream input = new FileInputStream(file)) {
             properties.load(input);
             enabled = Boolean.parseBoolean(properties.getProperty("enabled", "false"));
+            thresholdMaskEnabled = Boolean.parseBoolean(properties.getProperty("thresholdMaskEnabled", "false"));
             intervalSeconds = clamp(parseInt(properties, "intervalSeconds", DEFAULT_INTERVAL_SECONDS), 1, Integer.MAX_VALUE);
             nestCount = clamp(parseInt(properties, "nestCount", 3), MIN_NESTS, MAX_NESTS);
             resizeNests();
@@ -147,6 +165,9 @@ public class ChickenManagerData {
                 nest.setMinArea(parseInt(properties, prefix + "minArea", 500));
                 nest.setMaxArea(parseInt(properties, prefix + "maxArea", 8000));
                 nest.setMinCircularity(parseDouble(properties, prefix + "minCircularity", 0.5));
+                nest.setAutoThreshold(Boolean.parseBoolean(properties.getProperty(prefix + "autoThreshold", "true")));
+                nest.setThresholdMask(Boolean.parseBoolean(properties.getProperty(prefix + "thresholdMask", "false")));
+                nest.setOtsuOffset(parseInt(properties, prefix + "otsuOffset", 0));
             }
         } catch (IOException e) {
             logger.warn("Could not load chicken data from {}: {}", DATA_FILE, e.getMessage());

--- a/src/main/java/com/keroleap/immerreader/SharedData/ChickenNest.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/ChickenNest.java
@@ -12,6 +12,9 @@ public class ChickenNest {
     private int minArea = 500;
     private int maxArea = 8000;
     private double minCircularity = 0.5;
+    private boolean autoThreshold = true;
+    private boolean thresholdMask = false;
+    private int otsuOffset = 0;
 
     public int[] getXs() {
         return xs.clone();
@@ -63,6 +66,30 @@ public class ChickenNest {
 
     public void setMinCircularity(double minCircularity) {
         this.minCircularity = minCircularity;
+    }
+
+    public boolean isAutoThreshold() {
+        return autoThreshold;
+    }
+
+    public void setAutoThreshold(boolean autoThreshold) {
+        this.autoThreshold = autoThreshold;
+    }
+
+    public boolean isThresholdMask() {
+        return thresholdMask;
+    }
+
+    public void setThresholdMask(boolean thresholdMask) {
+        this.thresholdMask = thresholdMask;
+    }
+
+    public int getOtsuOffset() {
+        return otsuOffset;
+    }
+
+    public void setOtsuOffset(int otsuOffset) {
+        this.otsuOffset = otsuOffset;
     }
 
     public boolean isConfigured() {

--- a/src/main/resources/templates/chicken-manager.html
+++ b/src/main/resources/templates/chicken-manager.html
@@ -249,6 +249,29 @@
             background: #28a745;
             display: block;
         }
+        .legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-top: 10px;
+            font-size: 12px;
+            color: #aaa;
+        }
+        .legend span {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+        .legend-color {
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            border-radius: 2px;
+        }
+        .legend-color.green { background: #28a745; }
+        .legend-color.orange { background: #ffa500; }
+        .legend-color.yellow { background: #ffff00; }
+        .legend-color.red { background: #e94560; }
     </style>
 </head>
 <body>
@@ -278,6 +301,14 @@
                     <label class="toggle-label">
                         <span>Scheduler <span id="schedulerStatus" th:text="${enabled} ? 'Enabled' : 'Disabled'">Enabled</span></span>
                         <input type="checkbox" id="schedulerToggle" th:checked="${enabled}">
+                        <span class="toggle-switch"></span>
+                    </label>
+                </div>
+
+                <div class="toggle-section">
+                    <label class="toggle-label">
+                        <span>Debug Overlay <span id="debugStatus">Off</span></span>
+                        <input type="checkbox" id="debugToggle">
                         <span class="toggle-switch"></span>
                     </label>
                 </div>
@@ -346,6 +377,12 @@
                     <img id="liveImage" src="/Chicken/uncroppedimage" alt="Chicken Camera Feed">
                 </div>
                 <p><small>Image refreshes automatically every <span id="previewIntervalSeconds" th:text="${intervalSeconds}">30</span> seconds. Select a nest and a point, then click on the image to place the 4 polygon corners.</small></p>
+                <div class="legend">
+                    <span><span class="legend-color green"></span> Counted egg</span>
+                    <span><span class="legend-color orange"></span> Rejected: circularity/area</span>
+                    <span><span class="legend-color yellow"></span> Rejected: too small/large</span>
+                    <span><span class="legend-color red"></span> Outside polygon</span>
+                </div>
             </div>
 
             <div class="data-section">
@@ -387,6 +424,12 @@
         const pointButtonsContainer = document.getElementById('pointButtons');
         const dataGrid = document.getElementById('dataGrid');
         const nestCountSelect = document.getElementById('nestCount');
+        const debugToggle = document.getElementById('debugToggle');
+
+        function getImageUrl() {
+            const base = debugToggle.checked ? '/Chicken/debugimage' : '/Chicken/uncroppedimage';
+            return base + '?t=' + new Date().getTime();
+        }
 
         function initializeNests() {
             nests = [];
@@ -551,6 +594,12 @@
             showStatus(`Nest count changed to ${nestCount}. Click Apply All Nests to save.`, true);
         });
 
+        document.getElementById('debugToggle').addEventListener('change', function() {
+            const enabled = this.checked;
+            document.getElementById('debugStatus').textContent = enabled ? 'On' : 'Off';
+            refreshImage();
+        });
+
         document.getElementById('schedulerToggle').addEventListener('change', function() {
             fetch('/ChickenManager/toggle', { method: 'POST' })
             .then(response => response.json())
@@ -583,7 +632,7 @@
 
         function refreshImage() {
             const img = document.getElementById('liveImage');
-            img.src = '/Chicken/uncroppedimage?t=' + new Date().getTime();
+            img.src = getImageUrl();
         }
 
         function fetchData() {

--- a/src/main/resources/templates/chicken-manager.html
+++ b/src/main/resources/templates/chicken-manager.html
@@ -272,6 +272,10 @@
         .legend-color.orange { background: #ffa500; }
         .legend-color.yellow { background: #ffff00; }
         .legend-color.red { background: #e94560; }
+        .legend-color.blue { background: #008cff; }
+        .legend-color.dark-orange { background: #c86400; }
+        .legend-color.light-green { background: #80ff80; }
+        .legend-color.purple { background: #b400dc; }
     </style>
 </head>
 <body>
@@ -313,6 +317,14 @@
                     </label>
                 </div>
 
+                <div class="toggle-section">
+                    <label class="toggle-label">
+                        <span>Threshold Mask Overlay <span id="thresholdMaskStatus">Off</span></span>
+                        <input type="checkbox" id="thresholdMaskGlobalToggle" th:checked="${thresholdMaskEnabled}">
+                        <span class="toggle-switch"></span>
+                    </label>
+                </div>
+
                 <div id="controlsPanel" th:classappend="${!enabled} ? 'disabled-overlay' : ''">
                     <div class="form-group">
                         <label for="nestCount">Number of Nests:</label>
@@ -337,9 +349,17 @@
 
                     <form id="nestForm">
                         <div class="form-group">
+                            <label class="toggle-label" style="margin-bottom: 8px;">
+                                <span>Auto Threshold (Otsu)</span>
+                                <input type="checkbox" id="autoThresholdToggle">
+                                <span class="toggle-switch"></span>
+                            </label>
                             <label for="threshold">Threshold (0-255):</label>
                             <input type="number" id="threshold" name="threshold" min="0" max="255" required>
-                            <div class="hint">Bright IR egg spots must exceed this. Start with ~180.</div>
+                            <div class="hint">If Auto is on, Otsu computes this per nest. Manual value is still saved.</div>
+                            <label for="otsuOffset" style="margin-top: 10px;">Otsu Offset (±255):</label>
+                            <input type="number" id="otsuOffset" name="otsuOffset" min="-255" max="255" required>
+                            <div class="hint">Add this value to the computed Otsu threshold for this nest. Use positive values to raise threshold (helps separate merged eggs).</div>
                         </div>
 
                         <div class="form-group">
@@ -378,10 +398,11 @@
                 </div>
                 <p><small>Image refreshes automatically every <span id="previewIntervalSeconds" th:text="${intervalSeconds}">30</span> seconds. Select a nest and a point, then click on the image to place the 4 polygon corners.</small></p>
                 <div class="legend">
+                    <span><span class="legend-color blue"></span> Nest polygon</span>
                     <span><span class="legend-color green"></span> Counted egg</span>
-                    <span><span class="legend-color orange"></span> Rejected: circularity/area</span>
-                    <span><span class="legend-color yellow"></span> Rejected: too small/large</span>
-                    <span><span class="legend-color red"></span> Outside polygon</span>
+                    <span><span class="legend-color dark-orange"></span> Rejected contour</span>
+                    <span><span class="legend-color light-green"></span> Threshold mask</span>
+                    <span><span class="legend-color purple"></span> Merged / unsplit</span>
                 </div>
             </div>
 
@@ -431,6 +452,16 @@
             return base + '?t=' + new Date().getTime();
         }
 
+        function updateDebugUrlState() {
+            const url = new URL(window.location.href);
+            if (debugToggle.checked) {
+                url.searchParams.set('debug', '1');
+            } else {
+                url.searchParams.delete('debug');
+            }
+            window.history.replaceState({}, '', url.toString());
+        }
+
         function initializeNests() {
             nests = [];
             for (let i = 0; i < nestCount; i++) {
@@ -445,7 +476,10 @@
                     threshold: source ? source.threshold : 180,
                     minArea: source ? source.minArea : 500,
                     maxArea: source ? source.maxArea : 8000,
-                    minCircularity: source ? source.minCircularity : 0.5
+                    minCircularity: source ? source.minCircularity : 0.5,
+                    autoThreshold: source ? (source.autoThreshold === true || source.autoThreshold === 'true') : true,
+                    thresholdMask: source ? (source.thresholdMask === true || source.thresholdMask === 'true') : false,
+                    otsuOffset: source ? source.otsuOffset : 0
                 });
             }
         }
@@ -504,6 +538,8 @@
             document.getElementById('minArea').value = nest.minArea;
             document.getElementById('maxArea').value = nest.maxArea;
             document.getElementById('minCircularity').value = nest.minCircularity;
+            document.getElementById('autoThresholdToggle').checked = nest.autoThreshold;
+            document.getElementById('otsuOffset').value = nest.otsuOffset;
         }
 
         function toImageCoordinates(event) {
@@ -546,12 +582,17 @@
             nest.minArea = parseInt(document.getElementById('minArea').value);
             nest.maxArea = parseInt(document.getElementById('maxArea').value);
             nest.minCircularity = parseFloat(document.getElementById('minCircularity').value);
+            nest.autoThreshold = document.getElementById('autoThresholdToggle').checked;
+            nest.otsuOffset = parseInt(document.getElementById('otsuOffset').value || '0');
 
             const points = nests.map(n => n.xs.map((x, p) => `${x},${n.ys[p]}`).join(',')).join(',');
             const thresholds = nests.map(n => n.threshold).join(',');
             const minAreas = nests.map(n => n.minArea).join(',');
             const maxAreas = nests.map(n => n.maxArea).join(',');
             const minCircularities = nests.map(n => n.minCircularity).join(',');
+            const autoThresholds = nests.map(n => n.autoThreshold ? 'true' : 'false').join(',');
+            const thresholdMasks = nests.map(n => n.thresholdMask ? 'true' : 'false').join(',');
+            const otsuOffsets = nests.map(n => n.otsuOffset).join(',');
             const intervalSeconds = document.getElementById('intervalSeconds').value;
 
             fetch('/ChickenManager/set', {
@@ -559,7 +600,7 @@
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
                 },
-                body: `count=${nestCount}&points=${encodeURIComponent(points)}&thresholds=${encodeURIComponent(thresholds)}&minAreas=${encodeURIComponent(minAreas)}&maxAreas=${encodeURIComponent(maxAreas)}&minCircularities=${encodeURIComponent(minCircularities)}&intervalSeconds=${intervalSeconds}`
+                body: `count=${nestCount}&points=${encodeURIComponent(points)}&thresholds=${encodeURIComponent(thresholds)}&minAreas=${encodeURIComponent(minAreas)}&maxAreas=${encodeURIComponent(maxAreas)}&minCircularities=${encodeURIComponent(minCircularities)}&autoThresholds=${encodeURIComponent(autoThresholds)}&thresholdMasks=${encodeURIComponent(thresholdMasks)}&otsuOffsets=${encodeURIComponent(otsuOffsets)}&intervalSeconds=${intervalSeconds}`
             })
             .then(response => {
                 if (!response.ok) {
@@ -594,11 +635,43 @@
             showStatus(`Nest count changed to ${nestCount}. Click Apply All Nests to save.`, true);
         });
 
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.get('debug') === '1') {
+            debugToggle.checked = true;
+            document.getElementById('debugStatus').textContent = 'On';
+        }
+
+        const thresholdMaskGlobalToggle = document.getElementById('thresholdMaskGlobalToggle');
+        const thresholdMaskStatus = document.getElementById('thresholdMaskStatus');
+
+        function updateThresholdMaskStatus() {
+            thresholdMaskStatus.textContent = thresholdMaskGlobalToggle.checked ? 'On' : 'Off';
+        }
+
+        thresholdMaskGlobalToggle.addEventListener('change', function() {
+            updateThresholdMaskStatus();
+            fetch('/ChickenManager/toggleThresholdMask', { method: 'POST' })
+            .then(response => response.json())
+            .then(data => {
+                showStatus('Threshold mask ' + (data.thresholdMaskEnabled ? 'enabled' : 'disabled') + ' for all nests!', true);
+                refreshImage();
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                showStatus('Error: ' + error.message, false);
+            });
+        });
+
+        updateThresholdMaskStatus();
+
         document.getElementById('debugToggle').addEventListener('change', function() {
             const enabled = this.checked;
             document.getElementById('debugStatus').textContent = enabled ? 'On' : 'Off';
+            updateDebugUrlState();
             refreshImage();
         });
+
+        document.getElementById('previewIntervalSeconds').textContent = document.getElementById('intervalSeconds').value || '30';
 
         document.getElementById('schedulerToggle').addEventListener('change', function() {
             fetch('/ChickenManager/toggle', { method: 'POST' })
@@ -650,8 +723,66 @@
                     if (totalEl) {
                         totalEl.textContent = data.totalCount != null ? data.totalCount : 0;
                     }
+                    if (data.intervalSeconds != null) {
+                        const previewSpan = document.getElementById('previewIntervalSeconds');
+                        const input = document.getElementById('intervalSeconds');
+                        if (previewSpan && previewSpan.textContent !== String(data.intervalSeconds)) {
+                            previewSpan.textContent = data.intervalSeconds;
+                        }
+                        if (input && input.value !== String(data.intervalSeconds)) {
+                            input.value = data.intervalSeconds;
+                        }
+                    }
                 })
                 .catch(error => console.error('Error fetching Chicken data:', error));
+            fetchContourData();
+        }
+
+        function fetchContourData() {
+            fetch('/Chicken/contourdata')
+                .then(response => response.json())
+                .then(data => {
+                    renderContourTable(data);
+                })
+                .catch(error => console.error('Error fetching contour data:', error));
+        }
+
+        function renderContourTable(data) {
+            let container = document.getElementById('contourTableContainer');
+            if (!container) {
+                container = document.createElement('div');
+                container.id = 'contourTableContainer';
+                container.className = 'data-section';
+                container.innerHTML = '<h2>Detected Contours</h2><div id="contourTableWrapper" style="overflow-x:auto;"></div>';
+                const rightPanel = document.querySelector('.right-panel');
+                if (rightPanel) {
+                    rightPanel.appendChild(container);
+                }
+            }
+            const wrapper = document.getElementById('contourTableWrapper');
+            if (!data || data.length === 0) {
+                wrapper.innerHTML = '<p style="color:#aaa;">No contours detected.</p>';
+                return;
+            }
+            const headers = Object.keys(data[0]);
+            let html = '<table style="width:100%; border-collapse:collapse; font-size:12px;"><thead><tr>';
+            headers.forEach(h => html += `<th style="border:1px solid #0f3460; padding:6px; text-align:left;">${h}</th>`);
+            html += '</tr></thead><tbody>';
+            data.forEach(row => {
+                html += '<tr>';
+                headers.forEach(h => {
+                    let val = row[h];
+                    if (h === 'counted') {
+                        val = val ? '✅' : '❌';
+                    } else if (h === 'merged') {
+                        val = val ? 'Merged' : '';
+                    }
+                    html += `<td style="border:1px solid #0f3460; padding:6px;">${val != null ? val : ''}</td>`;
+                });
+                html += '</tr>';
+            });
+            html += '</tbody></table>';
+            wrapper.innerHTML = html;
         }
 
         liveImage.addEventListener('load', () => console.log('Chicken image loaded:', liveImage.naturalWidth, 'x', liveImage.naturalHeight));


### PR DESCRIPTION
This PR enhances the Chicken Manager egg counting pipeline with better thresholding, debuggability and merged-egg handling.

### What changed
- Per-nest Otsu threshold with a configurable manual offset.
- Global threshold mask overlay toggle under the debug overlay.
- Merged egg detection and splitting via distance-transform watershed; unresolved merged contours count as 2 eggs in debug overlay mode.
- New /Chicken/contourdata JSON endpoint powering a live detected-contours table in the UI.
- UI updates in chicken-manager.html: threshold mask switch, Otsu offset input, contours table.
- OpenCV support: added opencv-platform dependency and --enable-native-access=ALL-UNNAMED JVM flag.

### How to verify
1. Run mvn clean package.
2. Run mvn spring-boot:run.
3. Open /chickenmanager, enable Debug Overlay and Threshold Mask, adjust Otsu offset per nest.
4. Check /Chicken/contourdata and /Chicken/chickenrestdata for counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)