### PR TITLE
Fix: clear accumulated Chicken contour data before each scheduler run

### DIFF
--- a/src/main/java/com/keroleap/immerreader/Service/ChickenAnalyzerService.java
+++ b/src/main/java/com/keroleap/immerreader/Service/ChickenAnalyzerService.java
@@ -54,6 +54,9 @@ public class ChickenAnalyzerService {
     }
 
     public ChickenRest getChickenRestData(BufferedImage image, ChickenManagerData managerData) {
+        synchronized (accumulatedContourData) {
+            accumulatedContourData.clear();
+        }
         ChickenRest chickenRest = new ChickenRest();
         if (image == null) {
             chickenRest.setError(true);
@@ -88,7 +91,9 @@ public class ChickenAnalyzerService {
         graphics.setFont(new java.awt.Font("Arial", java.awt.Font.BOLD, 14));
         List<ChickenNest> nests = managerData.getNests();
 
-        accumulatedContourData.clear();
+        synchronized (accumulatedContourData) {
+            accumulatedContourData.clear();
+        }
 
         BufferedImage thresholdMaskLayer = createThresholdMaskLayer(copy, nests, managerData.isThresholdMaskEnabled());
         if (thresholdMaskLayer != null) {


### PR DESCRIPTION
## Problem\nThe  endpoint was accumulating contour entries across every scheduler run, so the list kept growing and contained many duplicates from previous runs.\n\n## Fix\nClear  at the start of  and inside , so the contour list always reflects only the most recent scheduler run or debug render.\n\n## Verification\nAll existing tests pass ([INFO] Scanning for projects...
[INFO] 
[INFO] ----------------------< com.keroleap:immerreader >----------------------
[INFO] Building immerreader 1.0.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ immerreader ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] Copying 9 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.13.0:compile (default-compile) @ immerreader ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ immerreader ---
[INFO] skip non existing resourceDirectory /home/kero/Dokumentumok/Development/Code/ImmerReader/src/test/resources
[INFO] 
[INFO] --- compiler:3.13.0:testCompile (default-testCompile) @ immerreader ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.5.3:test (default-test) @ immerreader ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.keroleap.immerreader.AristonRestTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.042 s -- in com.keroleap.immerreader.AristonRestTest
[INFO] Running com.keroleap.immerreader.ImmerRestTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in com.keroleap.immerreader.ImmerRestTest
[INFO] Running com.keroleap.immerreader.ImmerreaderApplicationTests
18:02:40.014 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [com.keroleap.immerreader.ImmerreaderApplicationTests]: ImmerreaderApplicationTests does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
18:02:40.076 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.ImmerreaderApplicationTests

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T18:02:40.289+02:00  INFO 10849 --- [           main] c.k.i.ImmerreaderApplicationTests        : Starting ImmerreaderApplicationTests using Java 25.0.4 with PID 10849 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T18:02:40.290+02:00  INFO 10849 --- [           main] c.k.i.ImmerreaderApplicationTests        : No active profile set, falling back to 1 default profile: "default"
AristonRest initialized at startup.
EbedloRest initialized at startup.
ImmerRest initialized at startup.
2026-08-15T18:02:40.791+02:00  INFO 10849 --- [           main] c.k.i.Scheduler.ChickenScheduler         : Chicken scheduler initialized.
2026-08-15T18:02:40.880+02:00  INFO 10849 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T18:02:41.157+02:00  INFO 10849 --- [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
2026-08-15T18:02:41.192+02:00  INFO 10849 --- [           main] c.k.i.ImmerreaderApplicationTests        : Started ImmerreaderApplicationTests in 1.046 seconds (process running for 1.694)
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.714 s -- in com.keroleap.immerreader.ImmerreaderApplicationTests
[INFO] Running com.keroleap.immerreader.Controller.ChickenManagerControllerTest
2026-08-15T18:02:41.641+02:00  INFO 10849 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.ChickenManagerControllerTest]: ChickenManagerControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T18:02:41.657+02:00  INFO 10849 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.ChickenManagerControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T18:02:41.673+02:00  INFO 10849 --- [           main] c.k.i.C.ChickenManagerControllerTest     : Starting ChickenManagerControllerTest using Java 25.0.4 with PID 10849 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T18:02:41.673+02:00  INFO 10849 --- [           main] c.k.i.C.ChickenManagerControllerTest     : No active profile set, falling back to 1 default profile: "default"
2026-08-15T18:02:41.875+02:00  INFO 10849 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T18:02:41.940+02:00  INFO 10849 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T18:02:41.940+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T18:02:41.941+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-15T18:02:41.950+02:00  INFO 10849 --- [           main] c.k.i.C.ChickenManagerControllerTest     : Started ChickenManagerControllerTest in 0.291 seconds (process running for 2.452)
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.406 s -- in com.keroleap.immerreader.Controller.ChickenManagerControllerTest
[INFO] Running com.keroleap.immerreader.Controller.HelloWorldControllerTest
2026-08-15T18:02:42.050+02:00  INFO 10849 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.HelloWorldControllerTest]: HelloWorldControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T18:02:42.055+02:00  INFO 10849 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.HelloWorldControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T18:02:42.070+02:00  INFO 10849 --- [           main] c.k.i.C.HelloWorldControllerTest         : Starting HelloWorldControllerTest using Java 25.0.4 with PID 10849 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T18:02:42.070+02:00  INFO 10849 --- [           main] c.k.i.C.HelloWorldControllerTest         : No active profile set, falling back to 1 default profile: "default"
2026-08-15T18:02:42.263+02:00  INFO 10849 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T18:02:42.298+02:00  INFO 10849 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T18:02:42.299+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T18:02:42.299+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-15T18:02:42.304+02:00  INFO 10849 --- [           main] c.k.i.C.HelloWorldControllerTest         : Started HelloWorldControllerTest in 0.246 seconds (process running for 2.806)
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.285 s -- in com.keroleap.immerreader.Controller.HelloWorldControllerTest
[INFO] Running com.keroleap.immerreader.Controller.AristonControllerTest
2026-08-15T18:02:42.335+02:00  INFO 10849 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.AristonControllerTest]: AristonControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T18:02:42.342+02:00  INFO 10849 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.AristonControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T18:02:42.359+02:00  INFO 10849 --- [           main] c.k.i.Controller.AristonControllerTest   : Starting AristonControllerTest using Java 25.0.4 with PID 10849 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T18:02:42.359+02:00  INFO 10849 --- [           main] c.k.i.Controller.AristonControllerTest   : No active profile set, falling back to 1 default profile: "default"
2026-08-15T18:02:42.505+02:00  INFO 10849 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T18:02:42.531+02:00  INFO 10849 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T18:02:42.531+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T18:02:42.532+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 1 ms
2026-08-15T18:02:42.535+02:00  INFO 10849 --- [           main] c.k.i.Controller.AristonControllerTest   : Started AristonControllerTest in 0.191 seconds (process running for 3.038)
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.219 s -- in com.keroleap.immerreader.Controller.AristonControllerTest
[INFO] Running com.keroleap.immerreader.Controller.ImmerManagerControllerTest
2026-08-15T18:02:42.556+02:00  INFO 10849 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.ImmerManagerControllerTest]: ImmerManagerControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T18:02:42.561+02:00  INFO 10849 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.ImmerManagerControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T18:02:42.572+02:00  INFO 10849 --- [           main] c.k.i.C.ImmerManagerControllerTest       : Starting ImmerManagerControllerTest using Java 25.0.4 with PID 10849 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T18:02:42.572+02:00  INFO 10849 --- [           main] c.k.i.C.ImmerManagerControllerTest       : No active profile set, falling back to 1 default profile: "default"
2026-08-15T18:02:42.633+02:00  INFO 10849 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T18:02:42.657+02:00  INFO 10849 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T18:02:42.657+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T18:02:42.657+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-15T18:02:42.660+02:00  INFO 10849 --- [           main] c.k.i.C.ImmerManagerControllerTest       : Started ImmerManagerControllerTest in 0.097 seconds (process running for 3.162)
2026-08-15T18:02:42.706+02:00  WARN 10849 --- [           main] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.web.bind.MissingServletRequestParameterException: Required request parameter 'y' for method parameter type int is not present]
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.165 s -- in com.keroleap.immerreader.Controller.ImmerManagerControllerTest
[INFO] Running com.keroleap.immerreader.Controller.EbedloManagerControllerTest
2026-08-15T18:02:42.723+02:00  INFO 10849 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.EbedloManagerControllerTest]: EbedloManagerControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T18:02:42.727+02:00  INFO 10849 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.EbedloManagerControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T18:02:42.741+02:00  INFO 10849 --- [           main] c.k.i.C.EbedloManagerControllerTest      : Starting EbedloManagerControllerTest using Java 25.0.4 with PID 10849 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T18:02:42.741+02:00  INFO 10849 --- [           main] c.k.i.C.EbedloManagerControllerTest      : No active profile set, falling back to 1 default profile: "default"
2026-08-15T18:02:42.855+02:00  INFO 10849 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T18:02:42.879+02:00  INFO 10849 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T18:02:42.879+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T18:02:42.879+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-15T18:02:42.883+02:00  INFO 10849 --- [           main] c.k.i.C.EbedloManagerControllerTest      : Started EbedloManagerControllerTest in 0.154 seconds (process running for 3.385)
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.199 s -- in com.keroleap.immerreader.Controller.EbedloManagerControllerTest
[INFO] Running com.keroleap.immerreader.Controller.AristonManagerControllerTest
2026-08-15T18:02:42.923+02:00  INFO 10849 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.AristonManagerControllerTest]: AristonManagerControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T18:02:42.927+02:00  INFO 10849 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.AristonManagerControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T18:02:42.941+02:00  INFO 10849 --- [           main] c.k.i.C.AristonManagerControllerTest     : Starting AristonManagerControllerTest using Java 25.0.4 with PID 10849 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T18:02:42.941+02:00  INFO 10849 --- [           main] c.k.i.C.AristonManagerControllerTest     : No active profile set, falling back to 1 default profile: "default"
2026-08-15T18:02:42.994+02:00  INFO 10849 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T18:02:43.019+02:00  INFO 10849 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T18:02:43.019+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T18:02:43.019+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-15T18:02:43.022+02:00  INFO 10849 --- [           main] c.k.i.C.AristonManagerControllerTest     : Started AristonManagerControllerTest in 0.092 seconds (process running for 3.524)
2026-08-15T18:02:43.061+02:00  WARN 10849 --- [           main] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.web.bind.MissingServletRequestParameterException: Required request parameter 'endY' for method parameter type int is not present]
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.145 s -- in com.keroleap.immerreader.Controller.AristonManagerControllerTest
[INFO] Running com.keroleap.immerreader.Controller.HomeControllerTest
2026-08-15T18:02:43.069+02:00  INFO 10849 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.HomeControllerTest]: HomeControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T18:02:43.074+02:00  INFO 10849 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.HomeControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T18:02:43.086+02:00  INFO 10849 --- [           main] c.k.i.Controller.HomeControllerTest      : Starting HomeControllerTest using Java 25.0.4 with PID 10849 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T18:02:43.086+02:00  INFO 10849 --- [           main] c.k.i.Controller.HomeControllerTest      : No active profile set, falling back to 1 default profile: "default"
2026-08-15T18:02:43.139+02:00  INFO 10849 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T18:02:43.165+02:00  INFO 10849 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T18:02:43.165+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T18:02:43.165+02:00  INFO 10849 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-15T18:02:43.167+02:00  INFO 10849 --- [           main] c.k.i.Controller.HomeControllerTest      : Started HomeControllerTest in 0.091 seconds (process running for 3.669)
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.274 s -- in com.keroleap.immerreader.Controller.HomeControllerTest
[INFO] Running com.keroleap.immerreader.SharedData.ImmerManagerDataTest
2026-08-15T18:02:43.343+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.345+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.345+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.345+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.345+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.345+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.346+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.346+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.346+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.346+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.347+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.347+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T18:02:43.347+02:00  WARN 10849 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.keroleap.immerreader.SharedData.ImmerManagerDataTest
[INFO] Running com.keroleap.immerreader.SharedData.AristonManagerDataTest
2026-08-15T18:02:43.349+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.349+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.349+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.349+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.350+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.350+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.352+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.352+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.352+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.352+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.352+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.352+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.352+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.353+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.353+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.354+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T18:02:43.354+02:00  WARN 10849 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.keroleap.immerreader.SharedData.AristonManagerDataTest
[INFO] Running com.keroleap.immerreader.Service.AristonAnalyzerServiceTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.048 s -- in com.keroleap.immerreader.Service.AristonAnalyzerServiceTest
[INFO] Running com.keroleap.immerreader.Service.ImmerAnalyzerServiceTest
2026-08-15T18:02:43.405+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.406+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.406+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.410+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.411+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.411+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.411+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.412+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.412+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.412+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: truefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.413+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.413+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.413+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T18:02:43.413+02:00  WARN 10849 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s -- in com.keroleap.immerreader.Service.ImmerAnalyzerServiceTest
[INFO] Running com.keroleap.immerreader.Scheduler.ImmerSchedulerTest
2026-08-15T18:02:43.427+02:00  INFO 10849 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
2026-08-15T18:02:43.430+02:00  INFO 10849 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
2026-08-15T18:02:43.430+02:00  INFO 10849 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
2026-08-15T18:02:43.434+02:00  INFO 10849 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s -- in com.keroleap.immerreader.Scheduler.ImmerSchedulerTest
[INFO] Running com.keroleap.immerreader.Scheduler.AristonSchedulerTest
2026-08-15T18:02:43.469+02:00  INFO 10849 --- [           main] c.k.i.Scheduler.AristonScheduler         : Shutting down AristonScheduler executor.
2026-08-15T18:02:43.476+02:00 ERROR 10849 --- [           main] c.k.i.Scheduler.AristonScheduler         : Error fetching Ariston data: Cannot invoke "com.keroleap.immerreader.SharedData.AristonData.setAristonRest(com.keroleap.immerreader.AristonRest)" because "this.aristonData" is null
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.041 s -- in com.keroleap.immerreader.Scheduler.AristonSchedulerTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 111, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.996 s
[INFO] Finished at: 2026-08-15T18:02:43+02:00
[INFO] ------------------------------------------------------------------------: 111 tests, 0 failures).\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)