### PR TITLE
Add enabled and thresholdMaskEnabled to ChickenRest JSON

### DIFF
--- a/src/main/java/com/keroleap/immerreader/ChickenRest.java
+++ b/src/main/java/com/keroleap/immerreader/ChickenRest.java
@@ -10,6 +10,8 @@ public class ChickenRest {
     private boolean error;
     private ErrorType errorType;
     private int intervalSeconds;
+    private boolean enabled;
+    private boolean thresholdMaskEnabled;
 
     public List<Integer> getNestCounts() {
         return nestCounts;
@@ -49,6 +51,22 @@ public class ChickenRest {
 
     public void setIntervalSeconds(int intervalSeconds) {
         this.intervalSeconds = intervalSeconds;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isThresholdMaskEnabled() {
+        return thresholdMaskEnabled;
+    }
+
+    public void setThresholdMaskEnabled(boolean thresholdMaskEnabled) {
+        this.thresholdMaskEnabled = thresholdMaskEnabled;
     }
 
     @Override

--- a/src/main/java/com/keroleap/immerreader/SharedData/ChickenData.java
+++ b/src/main/java/com/keroleap/immerreader/SharedData/ChickenData.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.keroleap.immerreader.ChickenRest;
@@ -20,6 +21,9 @@ public class ChickenData {
     private final List<Deque<Integer>> history = new ArrayList<>();
     private int configuredCount = 0;
     private int intervalSeconds = 30;
+
+    @Autowired
+    private ChickenManagerData chickenManagerData;
 
     public ChickenData() {
         resizeHistory(3);
@@ -44,11 +48,15 @@ public class ChickenData {
         rest.setNestCounts(smoothed);
         rest.setTotalCount(smoothed.stream().mapToInt(Integer::intValue).sum());
         rest.setIntervalSeconds(this.intervalSeconds);
+        rest.setEnabled(chickenManagerData.isEnabled());
+        rest.setThresholdMaskEnabled(chickenManagerData.isThresholdMaskEnabled());
         this.chickenRest = rest;
     }
 
     public synchronized ChickenRest getChickenRest() {
         chickenRest.setIntervalSeconds(this.intervalSeconds);
+        chickenRest.setEnabled(chickenManagerData.isEnabled());
+        chickenRest.setThresholdMaskEnabled(chickenManagerData.isThresholdMaskEnabled());
         return chickenRest;
     }
 


### PR DESCRIPTION
## What\nExposes the Chicken manager's own state via the existing  endpoint.\n\n## Why\nHome Assistant  switches need to read the current on/off state, e.g. . Before this change the state was only available on the manager HTML page, not as JSON.\n\n## Changes\n-  gained  and  boolean fields.\n-  and  now populate these fields from .\n\n## Example JSON\n\n\n## Verification\n[INFO] Scanning for projects...
[INFO] 
[INFO] ----------------------< com.keroleap:immerreader >----------------------
[INFO] Building immerreader 1.0.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ immerreader ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] Copying 9 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.13.0:compile (default-compile) @ immerreader ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ immerreader ---
[INFO] skip non existing resourceDirectory /home/kero/Dokumentumok/Development/Code/ImmerReader/src/test/resources
[INFO] 
[INFO] --- compiler:3.13.0:testCompile (default-testCompile) @ immerreader ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.5.3:test (default-test) @ immerreader ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.keroleap.immerreader.AristonRestTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.030 s -- in com.keroleap.immerreader.AristonRestTest
[INFO] Running com.keroleap.immerreader.ImmerRestTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.keroleap.immerreader.ImmerRestTest
[INFO] Running com.keroleap.immerreader.ImmerreaderApplicationTests
19:02:40.190 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [com.keroleap.immerreader.ImmerreaderApplicationTests]: ImmerreaderApplicationTests does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
19:02:40.250 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.ImmerreaderApplicationTests

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T19:02:40.444+02:00  INFO 31548 --- [           main] c.k.i.ImmerreaderApplicationTests        : Starting ImmerreaderApplicationTests using Java 25.0.4 with PID 31548 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T19:02:40.445+02:00  INFO 31548 --- [           main] c.k.i.ImmerreaderApplicationTests        : No active profile set, falling back to 1 default profile: "default"
AristonRest initialized at startup.
EbedloRest initialized at startup.
ImmerRest initialized at startup.
2026-08-15T19:02:40.908+02:00  INFO 31548 --- [           main] c.k.i.Scheduler.ChickenScheduler         : Chicken scheduler initialized.
2026-08-15T19:02:40.994+02:00  INFO 31548 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T19:02:41.256+02:00  INFO 31548 --- [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
2026-08-15T19:02:41.284+02:00  INFO 31548 --- [           main] c.k.i.ImmerreaderApplicationTests        : Started ImmerreaderApplicationTests in 0.97 seconds (process running for 1.568)
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.607 s -- in com.keroleap.immerreader.ImmerreaderApplicationTests
[INFO] Running com.keroleap.immerreader.Controller.ChickenManagerControllerTest
2026-08-15T19:02:41.726+02:00  INFO 31548 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.ChickenManagerControllerTest]: ChickenManagerControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T19:02:41.743+02:00  INFO 31548 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.ChickenManagerControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T19:02:41.758+02:00  INFO 31548 --- [           main] c.k.i.C.ChickenManagerControllerTest     : Starting ChickenManagerControllerTest using Java 25.0.4 with PID 31548 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T19:02:41.758+02:00  INFO 31548 --- [           main] c.k.i.C.ChickenManagerControllerTest     : No active profile set, falling back to 1 default profile: "default"
2026-08-15T19:02:41.947+02:00  INFO 31548 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T19:02:42.006+02:00  INFO 31548 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T19:02:42.006+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T19:02:42.008+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 1 ms
2026-08-15T19:02:42.016+02:00  INFO 31548 --- [           main] c.k.i.C.ChickenManagerControllerTest     : Started ChickenManagerControllerTest in 0.271 seconds (process running for 2.3)
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.376 s -- in com.keroleap.immerreader.Controller.ChickenManagerControllerTest
[INFO] Running com.keroleap.immerreader.Controller.HelloWorldControllerTest
2026-08-15T19:02:42.104+02:00  INFO 31548 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.HelloWorldControllerTest]: HelloWorldControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T19:02:42.110+02:00  INFO 31548 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.HelloWorldControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T19:02:42.123+02:00  INFO 31548 --- [           main] c.k.i.C.HelloWorldControllerTest         : Starting HelloWorldControllerTest using Java 25.0.4 with PID 31548 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T19:02:42.123+02:00  INFO 31548 --- [           main] c.k.i.C.HelloWorldControllerTest         : No active profile set, falling back to 1 default profile: "default"
2026-08-15T19:02:42.257+02:00  INFO 31548 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T19:02:42.286+02:00  INFO 31548 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T19:02:42.286+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T19:02:42.286+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-15T19:02:42.289+02:00  INFO 31548 --- [           main] c.k.i.C.HelloWorldControllerTest         : Started HelloWorldControllerTest in 0.177 seconds (process running for 2.573)
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.211 s -- in com.keroleap.immerreader.Controller.HelloWorldControllerTest
[INFO] Running com.keroleap.immerreader.Controller.AristonControllerTest
2026-08-15T19:02:42.316+02:00  INFO 31548 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.AristonControllerTest]: AristonControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T19:02:42.320+02:00  INFO 31548 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.AristonControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T19:02:42.331+02:00  INFO 31548 --- [           main] c.k.i.Controller.AristonControllerTest   : Starting AristonControllerTest using Java 25.0.4 with PID 31548 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T19:02:42.331+02:00  INFO 31548 --- [           main] c.k.i.Controller.AristonControllerTest   : No active profile set, falling back to 1 default profile: "default"
2026-08-15T19:02:42.452+02:00  INFO 31548 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T19:02:42.473+02:00  INFO 31548 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T19:02:42.473+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T19:02:42.473+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-15T19:02:42.476+02:00  INFO 31548 --- [           main] c.k.i.Controller.AristonControllerTest   : Started AristonControllerTest in 0.154 seconds (process running for 2.76)
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.176 s -- in com.keroleap.immerreader.Controller.AristonControllerTest
[INFO] Running com.keroleap.immerreader.Controller.ImmerManagerControllerTest
2026-08-15T19:02:42.492+02:00  INFO 31548 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.ImmerManagerControllerTest]: ImmerManagerControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T19:02:42.496+02:00  INFO 31548 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.ImmerManagerControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T19:02:42.505+02:00  INFO 31548 --- [           main] c.k.i.C.ImmerManagerControllerTest       : Starting ImmerManagerControllerTest using Java 25.0.4 with PID 31548 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T19:02:42.505+02:00  INFO 31548 --- [           main] c.k.i.C.ImmerManagerControllerTest       : No active profile set, falling back to 1 default profile: "default"
2026-08-15T19:02:42.556+02:00  INFO 31548 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T19:02:42.577+02:00  INFO 31548 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T19:02:42.577+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T19:02:42.578+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 1 ms
2026-08-15T19:02:42.581+02:00  INFO 31548 --- [           main] c.k.i.C.ImmerManagerControllerTest       : Started ImmerManagerControllerTest in 0.084 seconds (process running for 2.865)
2026-08-15T19:02:42.614+02:00  WARN 31548 --- [           main] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.web.bind.MissingServletRequestParameterException: Required request parameter 'y' for method parameter type int is not present]
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.134 s -- in com.keroleap.immerreader.Controller.ImmerManagerControllerTest
[INFO] Running com.keroleap.immerreader.Controller.EbedloManagerControllerTest
2026-08-15T19:02:42.626+02:00  INFO 31548 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.EbedloManagerControllerTest]: EbedloManagerControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T19:02:42.630+02:00  INFO 31548 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.EbedloManagerControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T19:02:42.639+02:00  INFO 31548 --- [           main] c.k.i.C.EbedloManagerControllerTest      : Starting EbedloManagerControllerTest using Java 25.0.4 with PID 31548 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T19:02:42.639+02:00  INFO 31548 --- [           main] c.k.i.C.EbedloManagerControllerTest      : No active profile set, falling back to 1 default profile: "default"
2026-08-15T19:02:42.735+02:00  INFO 31548 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T19:02:42.753+02:00  INFO 31548 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T19:02:42.753+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T19:02:42.754+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 1 ms
2026-08-15T19:02:42.756+02:00  INFO 31548 --- [           main] c.k.i.C.EbedloManagerControllerTest      : Started EbedloManagerControllerTest in 0.125 seconds (process running for 3.04)
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.156 s -- in com.keroleap.immerreader.Controller.EbedloManagerControllerTest
[INFO] Running com.keroleap.immerreader.Controller.AristonManagerControllerTest
2026-08-15T19:02:42.784+02:00  INFO 31548 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.AristonManagerControllerTest]: AristonManagerControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T19:02:42.787+02:00  INFO 31548 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.AristonManagerControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T19:02:42.795+02:00  INFO 31548 --- [           main] c.k.i.C.AristonManagerControllerTest     : Starting AristonManagerControllerTest using Java 25.0.4 with PID 31548 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T19:02:42.796+02:00  INFO 31548 --- [           main] c.k.i.C.AristonManagerControllerTest     : No active profile set, falling back to 1 default profile: "default"
2026-08-15T19:02:42.841+02:00  INFO 31548 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T19:02:42.859+02:00  INFO 31548 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T19:02:42.859+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T19:02:42.859+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-15T19:02:42.862+02:00  INFO 31548 --- [           main] c.k.i.C.AristonManagerControllerTest     : Started AristonManagerControllerTest in 0.074 seconds (process running for 3.146)
2026-08-15T19:02:42.894+02:00  WARN 31548 --- [           main] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.web.bind.MissingServletRequestParameterException: Required request parameter 'endY' for method parameter type int is not present]
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.115 s -- in com.keroleap.immerreader.Controller.AristonManagerControllerTest
[INFO] Running com.keroleap.immerreader.Controller.HomeControllerTest
2026-08-15T19:02:42.900+02:00  INFO 31548 --- [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [com.keroleap.immerreader.Controller.HomeControllerTest]: HomeControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-08-15T19:02:42.903+02:00  INFO 31548 --- [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration com.keroleap.immerreader.ImmerreaderApplication for test class com.keroleap.immerreader.Controller.HomeControllerTest

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.5)

2026-08-15T19:02:42.913+02:00  INFO 31548 --- [           main] c.k.i.Controller.HomeControllerTest      : Starting HomeControllerTest using Java 25.0.4 with PID 31548 (started by kero in /home/kero/Dokumentumok/Development/Code/ImmerReader)
2026-08-15T19:02:42.913+02:00  INFO 31548 --- [           main] c.k.i.Controller.HomeControllerTest      : No active profile set, falling back to 1 default profile: "default"
2026-08-15T19:02:42.954+02:00  INFO 31548 --- [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page template: index
2026-08-15T19:02:42.971+02:00  INFO 31548 --- [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-08-15T19:02:42.971+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-08-15T19:02:42.971+02:00  INFO 31548 --- [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 0 ms
2026-08-15T19:02:42.973+02:00  INFO 31548 --- [           main] c.k.i.Controller.HomeControllerTest      : Started HomeControllerTest in 0.069 seconds (process running for 3.257)
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.225 s -- in com.keroleap.immerreader.Controller.HomeControllerTest
[INFO] Running com.keroleap.immerreader.SharedData.ImmerManagerDataTest
2026-08-15T19:02:43.125+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.127+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.127+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.127+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.127+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.127+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.128+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.128+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.128+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.128+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.129+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.129+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
2026-08-15T19:02:43.129+02:00  WARN 31548 --- [           main] c.k.i.SharedData.ImmerManagerData        : Could not save offset data to /data/offset.properties: /data/offset.properties (Engedély megtagadva)
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.keroleap.immerreader.SharedData.ImmerManagerDataTest
[INFO] Running com.keroleap.immerreader.SharedData.AristonManagerDataTest
2026-08-15T19:02:43.131+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.131+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.131+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.131+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.131+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.132+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.133+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.134+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.134+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.134+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.134+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.134+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.134+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.135+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.135+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.135+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
2026-08-15T19:02:43.136+02:00  WARN 31548 --- [           main] c.k.i.SharedData.AristonManagerData      : Could not save offset data to /data/ariston.properties: /data/ariston.properties (Engedély megtagadva)
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.keroleap.immerreader.SharedData.AristonManagerDataTest
[INFO] Running com.keroleap.immerreader.Service.AristonAnalyzerServiceTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.044 s -- in com.keroleap.immerreader.Service.AristonAnalyzerServiceTest
[INFO] Running com.keroleap.immerreader.Service.ImmerAnalyzerServiceTest
2026-08-15T19:02:43.183+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.183+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.183+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.186+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.187+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.187+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.187+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.188+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.188+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.188+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: truefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.189+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.189+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.189+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
2026-08-15T19:02:43.189+02:00  WARN 31548 --- [           main] c.k.i.Service.ImmerAnalyzerService       : Unknown digit detected: falsefalsefalsefalsefalsefalsefalse
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in com.keroleap.immerreader.Service.ImmerAnalyzerServiceTest
[INFO] Running com.keroleap.immerreader.Scheduler.ImmerSchedulerTest
2026-08-15T19:02:43.202+02:00  INFO 31548 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
2026-08-15T19:02:43.205+02:00  INFO 31548 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
2026-08-15T19:02:43.205+02:00  INFO 31548 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
2026-08-15T19:02:43.208+02:00  INFO 31548 --- [           main] c.k.i.Scheduler.ImmerScheduler           : Shutting down ImmerScheduler.
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s -- in com.keroleap.immerreader.Scheduler.ImmerSchedulerTest
[INFO] Running com.keroleap.immerreader.Scheduler.AristonSchedulerTest
2026-08-15T19:02:43.244+02:00  INFO 31548 --- [           main] c.k.i.Scheduler.AristonScheduler         : Shutting down AristonScheduler executor.
2026-08-15T19:02:43.250+02:00 ERROR 31548 --- [           main] c.k.i.Scheduler.AristonScheduler         : Error fetching Ariston data: Cannot invoke "com.keroleap.immerreader.SharedData.AristonData.setAristonRest(com.keroleap.immerreader.AristonRest)" because "this.aristonData" is null
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.042 s -- in com.keroleap.immerreader.Scheduler.AristonSchedulerTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 111, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.270 s
[INFO] Finished at: 2026-08-15T19:02:43+02:00
[INFO] ------------------------------------------------------------------------: 111 tests run, 0 failures.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)