### PR TITLE
Stop RTSP streams when Chicken/Ebedlo schedulers are disabled

### DIFF
--- a/src/main/java/com/keroleap/immerreader/Scheduler/ChickenScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/ChickenScheduler.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 import com.keroleap.immerreader.ChickenRest;
 import com.keroleap.immerreader.ErrorType;
 import com.keroleap.immerreader.Service.ChickenAnalyzerService;
+import com.keroleap.immerreader.Service.RtspFrameGrabber;
 import com.keroleap.immerreader.SharedData.ChickenData;
 import com.keroleap.immerreader.SharedData.ChickenManagerData;
 import com.keroleap.immerreader.SharedData.ErrorStatistics;
@@ -52,6 +53,9 @@ public class ChickenScheduler {
     @Autowired
     private SchedulerHealthTracker schedulerHealthTracker;
 
+    @Autowired
+    private RtspFrameGrabber rtspFrameGrabber;
+
     private ScheduledExecutorService scheduler;
     private ExecutorService executor;
     private final AtomicInteger consecutiveErrors = new AtomicInteger(0);
@@ -75,6 +79,7 @@ public class ChickenScheduler {
             consecutiveErrors.set(0);
             lastErrorType = null;
             chickenData.addCounts(java.util.Collections.nCopies(chickenManagerData.getNestCount(), 0));
+            rtspFrameGrabber.stopStream(cameraUrl);
             return;
         }
 

--- a/src/main/java/com/keroleap/immerreader/Scheduler/EbedloScheduler.java
+++ b/src/main/java/com/keroleap/immerreader/Scheduler/EbedloScheduler.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Component;
 import com.keroleap.immerreader.EbedloRest;
 import com.keroleap.immerreader.ErrorType;
 import com.keroleap.immerreader.Service.EbedloAnalyzerService;
+import com.keroleap.immerreader.Service.RtspFrameGrabber;
 import com.keroleap.immerreader.SharedData.EbedloData;
 import com.keroleap.immerreader.SharedData.EbedloManagerData;
 import com.keroleap.immerreader.SharedData.ErrorStatistics;
@@ -56,6 +57,9 @@ public class EbedloScheduler {
 
     @Autowired
     private TaskScheduler taskScheduler;
+
+    @Autowired
+    private RtspFrameGrabber rtspFrameGrabber;
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final AtomicInteger consecutiveErrors = new AtomicInteger(0);
@@ -93,6 +97,7 @@ public class EbedloScheduler {
         if (!ebedloManagerData.isEnabled()) {
             consecutiveErrors.set(0);
             lastErrorType = null;
+            rtspFrameGrabber.stopStream(cameraUrl);
             return;
         }
 

--- a/src/main/java/com/keroleap/immerreader/Service/RtspFrameGrabber.java
+++ b/src/main/java/com/keroleap/immerreader/Service/RtspFrameGrabber.java
@@ -32,6 +32,14 @@ public class RtspFrameGrabber {
         return holder.getFrame();
     }
 
+    public void stopStream(String rtspUrl) {
+        StreamHolder holder = holders.remove(rtspUrl);
+        if (holder != null) {
+            logger.info("Stopping RTSP stream for {}", rtspUrl);
+            holder.stop();
+        }
+    }
+
     @PreDestroy
     public void destroy() {
         shutdown.set(true);


### PR DESCRIPTION
## Problem

When the Chicken or Ebedlo scheduler was disabled via the management endpoints, the underlying RTSP worker thread in `RtspFrameGrabber` continued to run in the background, keeping the camera connection alive unnecessarily.

## Change

- Added `stopStream(String rtspUrl)` to `RtspFrameGrabber` to stop and remove a specific stream holder.
- `ChickenScheduler.run()` now calls `rtspFrameGrabber.stopStream(cameraUrl)` when disabled.
- `EbedloScheduler.EbedloScheduledRead()` now does the same.

## Behavior

| Scheduler state | RTSP connection |
|-----------------|-----------------|
| Never enabled | No connection |
| Enabled | Connection established on first read |
| Disabled after being enabled | **Connection stopped** |
| Re-enabled | Connection rebuilt from scratch |

## Verification

- `mvn -q compile` succeeds.
- Existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)