### PR TITLE
Limit RTSP grabber frame rate to reduce CPU usage

### DIFF
--- a/src/main/java/com/keroleap/immerreader/Service/RtspFrameGrabber.java
+++ b/src/main/java/com/keroleap/immerreader/Service/RtspFrameGrabber.java
@@ -8,6 +8,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.springframework.beans.factory.annotation.Value;
+
 import org.bytedeco.javacv.FFmpegFrameGrabber;
 import org.bytedeco.javacv.Frame;
 import org.bytedeco.javacv.Java2DFrameConverter;
@@ -23,12 +25,16 @@ public class RtspFrameGrabber {
     private static final Logger logger = LoggerFactory.getLogger(RtspFrameGrabber.class);
     private static final long FRAME_TIMEOUT_MS = 10000;
     private static final long GRABBER_ERROR_DELAY_MS = 2000;
+    private static final long DEFAULT_TARGET_FPS = 2;
+
+    @Value("${rtsp.target.fps:2}")
+    private long targetFps;
 
     private final Map<String, StreamHolder> holders = new ConcurrentHashMap<>();
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
     public BufferedImage getLatestFrame(String rtspUrl) {
-        StreamHolder holder = holders.computeIfAbsent(rtspUrl, StreamHolder::new);
+        StreamHolder holder = holders.computeIfAbsent(rtspUrl, key -> new StreamHolder(key, targetFps));
         return holder.getFrame();
     }
 
@@ -48,13 +54,15 @@ public class RtspFrameGrabber {
 
     private class StreamHolder {
         private final String rtspUrl;
+        private final long targetFps;
         private final ReentrantLock lock = new ReentrantLock();
         private final AtomicLong lastFrameTime = new AtomicLong(0);
         private volatile BufferedImage latestFrame;
         private volatile Thread workerThread;
 
-        StreamHolder(String rtspUrl) {
+        StreamHolder(String rtspUrl, long targetFps) {
             this.rtspUrl = rtspUrl;
+            this.targetFps = Math.max(1, targetFps);
             startWorker();
         }
 
@@ -104,12 +112,14 @@ public class RtspFrameGrabber {
         }
 
         void runGrabber() {
-            logger.info("Starting RTSP grabber for {}", rtspUrl);
+            long grabIntervalMs = 1000 / targetFps;
+            logger.info("Starting RTSP grabber for {} at {} fps ({} ms between grabs)", rtspUrl, targetFps, grabIntervalMs);
             while (!shutdown.get() && !Thread.currentThread().isInterrupted()) {
                 try (FFmpegFrameGrabber grabber = createGrabber();
                      Java2DFrameConverter converter = new Java2DFrameConverter()) {
                     grabber.start();
                     while (!shutdown.get() && !Thread.currentThread().isInterrupted()) {
+                        long loopStart = System.currentTimeMillis();
                         Frame frame = grabber.grabImage();
                         if (frame == null) {
                             break;
@@ -118,6 +128,16 @@ public class RtspFrameGrabber {
                         if (image != null) {
                             latestFrame = image;
                             lastFrameTime.set(System.currentTimeMillis());
+                        }
+                        long elapsed = System.currentTimeMillis() - loopStart;
+                        long sleepMs = grabIntervalMs - elapsed;
+                        if (sleepMs > 0) {
+                            try {
+                                Thread.sleep(sleepMs);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                break;
+                            }
                         }
                     }
                 } catch (Exception e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 server.port=8099
 camera.ebedlo.url=rtsp://frigate:utcatapo@192.168.1.194:554/stream1
 camera.chicken.url=rtsp://frigate:tyukolcam@192.168.1.185:554/stream2
+rtsp.target.fps=2


### PR DESCRIPTION
## Problem\n\nThe RTSP worker thread was decoding every frame the camera sent, causing high CPU usage even though the Chicken and Ebedlo schedulers only need a fresh image every few seconds.\n\n## Change\n\n- Added configurable `rtsp.target.fps` property (default 2 fps).\n- The grab loop now sleeps between successful grabs to enforce the target rate.\n- Added the property to `application.properties`.\n\n## Example\n\n```properties\nrtsp.target.fps=2\n```\n\nAt 2 fps the worker grabs a new frame every ~500 ms. This is more than enough for the 15-30 second scheduler intervals and significantly reduces CPU load.\n\n## Verification\n\n- `mvn -q compile` succeeds.\n- Existing scheduler and manager controller tests still pass.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)